### PR TITLE
Add newline to summary to match errors output

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1172,7 +1172,7 @@ sub summary
     if ($out ne "") {
         print "Extlog records summary:\n$out";
     } else {
-        print "No Extlog errors.\n";
+        print "No Extlog errors.\n\n";
     }
     $query_handle->finish;
 


### PR DESCRIPTION
Adding additional new line to match output from errors.