### PR TITLE
ras-mc-ctl: PCIe AER: display PCIe dev name

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1230,7 +1230,7 @@ sub summary
 sub errors
 {
     require DBI;
-    my ($query, $query_handle, $id, $time, $count, $type, $msg, $label, $mc, $top, $mid, $low, $addr, $grain, $syndrome, $detail, $out);
+    my ($query, $query_handle, $id, $time, $devname, $count, $type, $msg, $label, $mc, $top, $mid, $low, $addr, $grain, $syndrome, $detail, $out);
     my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $mcgstatus_msg, $mcistatus_msg, $user_action, $mc_location);
     my ($timestamp, $etype, $severity, $etype_string, $severity_string, $fru_id, $fru_text, $cper_data);
     my ($bus_name, $dev_name, $driver_name, $reporter_name);
@@ -1259,13 +1259,13 @@ sub errors
     $query_handle->finish;
 
     # PCIe AER aer_event errors
-    $query = "select id, timestamp, err_type, err_msg from aer_event order by id";
+    $query = "select id, timestamp, dev_name, err_type, err_msg from aer_event order by id";
     $query_handle = $dbh->prepare($query);
     $query_handle->execute();
-    $query_handle->bind_columns(\($id, $time, $type, $msg));
+    $query_handle->bind_columns(\($id, $time, $devname, $type, $msg));
     $out = "";
     while($query_handle->fetch()) {
-        $out .= "$id $time $type error: $msg\n";
+        $out .= "$id $time $devname $type error: $msg\n";
     }
     if ($out ne "") {
         print "PCIe AER events:\n$out\n";


### PR DESCRIPTION
Storage of PCIe dev name was added in commit 8e96ca2c1c59 ("rasdaemon:
store PCIe dev name and TLP header for the aer event"). This makes
ras-mc-ctl extract and emit it like so:

PCIe AER events:
1 2020-04-16 22:09:48 +0000 0000:0b:00.0 Corrected error: Receiver Error
2 2020-04-16 22:23:24 +0000 0000:0b:00.0 Corrected error: Receiver Error
3 2020-04-17 23:00:37 +0000 0000:d9:01.0 Corrected error: Advisory Non-Fatal, BIT15
4 2020-04-17 23:21:52 +0000 0000:d9:01.0 Corrected error: Advisory Non-Fatal
5 2020-04-18 02:04:24 +0000 0000:5e:00.0 Corrected error: Receiver Error

Signed-off-by: dann frazier <dann.frazier@canonical.com>