### PR TITLE
rasdaemon: Fix error print

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -874,7 +874,7 @@ int handle_ras_events(int record_events)
 		num_events++;
 	} else
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
-		    "ras", "aer_event");
+		    "ras", "extlog_mem_event");
 #endif
 
 #ifdef HAVE_DEVLINK


### PR DESCRIPTION
Fix error print handle_ras_events.

Signed-off-by: Liguang Zhang <zhangliguang@linux.alibaba.com>