### PR TITLE
Create SYSCONFDEFDIR configure parameter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = $(SYSTEMD_SERVICES_IN) misc/rasdaemon.env
 # files to AC_CONFIG_FILES in configure.ac
 SUFFIXES = .service.in .service
 .service.in.service:
-	sed -e s,\@sbindir\@,$(sbindir),g $< > $@
+	sed -e s,\@sbindir\@,$(sbindir),g -e s,\@SYSCONFDEFDIR\@,@SYSCONFDEFDIR@,g $< > $@
 
 # This rule is needed because the service files must be generated on target
 # system after ./configure phase
@@ -91,5 +91,5 @@ install-data-local:
 	$(install_sh) -d "$(DESTDIR)@RASSTATEDIR@"
 	$(install_sh) -d "$(DESTDIR)@sysconfdir@/ras/dimm_labels.d"
 if WITH_MEMORY_CE_PFA
-	$(install_sh) @abs_srcdir@/misc/rasdaemon.env "$(DESTDIR)@sysconfdir@/sysconfig/rasdaemon"
+	$(install_sh) @abs_srcdir@/misc/rasdaemon.env "$(DESTDIR)@SYSCONFDEFDIR@/rasdaemon"
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,12 @@ AC_SUBST([rasstatedir], [$localstatedir/lib/rasdaemon])
 AC_DEFINE_DIR([RASSTATEDIR], [rasstatedir], [rasdaemon db store state dir])
 AC_SUBST([RASSTATEDIR])
 
+AC_ARG_WITH(sysconfdefdir,
+    AC_HELP_STRING([--with-sysconfdefdir=DIR], [rasdaemon environment file dir]),
+    [SYSCONFDEFDIR=$withval],
+    [/etc/sysconfig])
+AC_SUBST([SYSCONFDEFDIR])
+
 AC_DEFINE([RAS_DB_FNAME], ["ras-mc_event.db"], [ras events database])
 AC_SUBST([RAS_DB_FNAME], ["ras-mc_event.db"])
 

--- a/misc/rasdaemon.service.in
+++ b/misc/rasdaemon.service.in
@@ -3,7 +3,7 @@ Description=RAS daemon to log the RAS events
 After=syslog.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/rasdaemon
+EnvironmentFile=@SYSCONFDEFDIR@/rasdaemon
 ExecStart=@sbindir@/rasdaemon -f -r
 ExecStartPost=@sbindir@/rasdaemon --enable
 ExecStop=@sbindir@/rasdaemon --disable

--- a/misc/rasdaemon.spec.in
+++ b/misc/rasdaemon.spec.in
@@ -56,8 +56,8 @@ rm INSTALL %{buildroot}/usr/include/*.h
 %{_unitdir}/*.service
 %{_sharedstatedir}/rasdaemon
 %{_sysconfdir}/ras/dimm_labels.d
-%{_sysconfdir}/sysconfig/%{name}
-%config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+@SYSCONFDEFDIR@/%{name}
+%config(noreplace) @SYSCONFDIFDIR@/%{name}
 
 %changelog
 


### PR DESCRIPTION
Provide downstream packagers with a tunable describing the location of the file containing environment variables to pass to the startup script.

Defaults to the previous value, /etc/sysconfig.

This addresses #21, and, if accepted, will address a downstream [Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966698).

I've tested this with associated changes to Debian packaging.