### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
   - env: TARGET_OS=bionic
   - compiler: clang
     env: TARGET_OS=bionic
+  #powerjobs
+  - env: TARGET_OS=bionic
+    arch: ppc64le
+  - compiler: clang
+    arch: ppc64le
+    env: TARGET_OS=bionic    
 before_install:
 - sudo apt-get install -y sqlite3
 install:


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
