### PR TITLE
Fix problem from make dist-rpm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,13 +57,16 @@ endif
 if WITH_MEMORY_CE_PFA
    rasdaemon_SOURCES += rbtree.c ras-page-isolation.c
 endif
+if WITH_AMP_NS_DECODE
+   rasdaemon_SOURCES += non-standard-ampere.c
+endif
 rasdaemon_LDADD = -lpthread $(SQLITE3_LIBS) libtrace/libtrace.a
 
 include_HEADERS = config.h  ras-events.h  ras-logger.h  ras-mc-handler.h \
 		  ras-aer-handler.h ras-mce-handler.h ras-record.h bitfield.h ras-report.h \
 		  ras-extlog-handler.h ras-arm-handler.h ras-non-standard-handler.h \
 		  ras-devlink-handler.h ras-diskerror-handler.h rbtree.h ras-page-isolation.h \
-                  non-standard-hisilicon.h
+                  non-standard-hisilicon.h non-standard-ampere.h
 
 # This rule can't be called with more than one Makefile job (like make -j8)
 # I can't figure out a way to fix that

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,8 @@ rasdaemon_LDADD = -lpthread $(SQLITE3_LIBS) libtrace/libtrace.a
 include_HEADERS = config.h  ras-events.h  ras-logger.h  ras-mc-handler.h \
 		  ras-aer-handler.h ras-mce-handler.h ras-record.h bitfield.h ras-report.h \
 		  ras-extlog-handler.h ras-arm-handler.h ras-non-standard-handler.h \
-		  ras-devlink-handler.h ras-diskerror-handler.h rbtree.h ras-page-isolation.h
+		  ras-devlink-handler.h ras-diskerror-handler.h rbtree.h ras-page-isolation.h \
+                  non-standard-hisilicon.h
 
 # This rule can't be called with more than one Makefile job (like make -j8)
 # I can't figure out a way to fix that

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,7 @@ AC_SUBST([RASSTATEDIR])
 AC_ARG_WITH(sysconfdefdir,
     AC_HELP_STRING([--with-sysconfdefdir=DIR], [rasdaemon environment file dir]),
     [SYSCONFDEFDIR=$withval],
-    [/etc/sysconfig])
+    ["/etc/sysconfig"])
 AC_SUBST([SYSCONFDEFDIR])
 
 AC_DEFINE([RAS_DB_FNAME], ["ras-mc_event.db"], [ras events database])

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,16 @@ AS_IF([test "x$enable_memory_ce_pfa" = "xyes" || test "x$enable_all" == "xyes"],
 AM_CONDITIONAL([WITH_MEMORY_CE_PFA], [test x$enable_memory_ce_pfa = xyes || test x$enable_all == xyes])
 AM_COND_IF([WITH_MEMORY_CE_PFA], [USE_MEMORY_CE_PFA="yes"], [USE_MEMORY_CE_PFA="no"])
 
+AC_ARG_ENABLE([amp_ns_decode],
+    AS_HELP_STRING([--enable-amp-ns-decode], [enable AMP_NS_DECODE events (currently experimental)]))
+
+AS_IF([test "x$enable_amp_ns_decode" = "xyes" || test "x$enable_all" == "xyes"], [
+  AC_DEFINE(HAVE_AMP_NS_DECODE,1,"have AMP UNKNOWN_SEC events decode")
+  AC_SUBST([WITH_AMP_NS_DECODE])
+])
+AM_CONDITIONAL([WITH_AMP_NS_DECODE], [test x$enable_amp_ns_decode = xyes || test x$enable_all == xyes])
+AM_COND_IF([WITH_AMP_NS_DECODE], [USE_AMP_NS_DECODE="yes"], [USE_AMP_NS_DECODE="no"])
+
 test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc
 
 CFLAGS="$CFLAGS -Wall -Wmissing-prototypes -Wstrict-prototypes"
@@ -179,4 +189,5 @@ compile time options summary
     DEVLINK             : $USE_DEVLINK
     Disk I/O errors     : $USE_DISKERROR
     Memory CE PFA       : $USE_MEMORY_CE_PFA
+    AMP RAS errors      : $USE_AMP_NS_DECODE
 EOF

--- a/misc/rasdaemon.spec.in
+++ b/misc/rasdaemon.spec.in
@@ -57,7 +57,7 @@ rm INSTALL %{buildroot}/usr/include/*.h
 %{_sharedstatedir}/rasdaemon
 %{_sysconfdir}/ras/dimm_labels.d
 @SYSCONFDEFDIR@/%{name}
-%config(noreplace) @SYSCONFDIFDIR@/%{name}
+%config(noreplace) @SYSCONFDEFDIR@/%{name}
 
 %changelog
 

--- a/non-standard-ampere.c
+++ b/non-standard-ampere.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, Ampere Computing LLC.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include "ras-record.h"
+#include "ras-logger.h"
+#include "ras-report.h"
+#include "ras-non-standard-handler.h"
+#include "non-standard-ampere.h"
+

--- a/non-standard-ampere.h
+++ b/non-standard-ampere.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020, Ampere Computing LLC.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ */
+
+
+#ifndef __NON_STANDARD_AMPERE_H
+#define __NON_STANDARD_AMPERE_H
+
+#endif


### PR DESCRIPTION
rasdaemon rpm package can't build out and report the files should start
from "/".

Update the Makefile by adding "" to folder name and change one
typo.

Signed-off-by: Jason_Tian <jason@os.amperecomputing.com>