### PR TITLE
Fix problem from make dist-rpm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,8 @@ rasdaemon_LDADD = -lpthread $(SQLITE3_LIBS) libtrace/libtrace.a
 include_HEADERS = config.h  ras-events.h  ras-logger.h  ras-mc-handler.h \
 		  ras-aer-handler.h ras-mce-handler.h ras-record.h bitfield.h ras-report.h \
 		  ras-extlog-handler.h ras-arm-handler.h ras-non-standard-handler.h \
-		  ras-devlink-handler.h ras-diskerror-handler.h rbtree.h ras-page-isolation.h
+		  ras-devlink-handler.h ras-diskerror-handler.h rbtree.h ras-page-isolation.h \
+		  non-standard-hisilicon.h
 
 # This rule can't be called with more than one Makefile job (like make -j8)
 # I can't figure out a way to fix that

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,7 @@ AC_SUBST([RASSTATEDIR])
 AC_ARG_WITH(sysconfdefdir,
     AC_HELP_STRING([--with-sysconfdefdir=DIR], [rasdaemon environment file dir]),
     [SYSCONFDEFDIR=$withval],
-    [/etc/sysconfig])
+    ["/etc/sysconfig"])
 AC_SUBST([SYSCONFDEFDIR])
 
 AC_DEFINE([RAS_DB_FNAME], ["ras-mc_event.db"], [ras events database])

--- a/misc/rasdaemon.spec.in
+++ b/misc/rasdaemon.spec.in
@@ -57,7 +57,7 @@ rm INSTALL %{buildroot}/usr/include/*.h
 %{_sharedstatedir}/rasdaemon
 %{_sysconfdir}/ras/dimm_labels.d
 @SYSCONFDEFDIR@/%{name}
-%config(noreplace) @SYSCONFDIFDIR@/%{name}
+%config(noreplace) @SYSCONFDEFDIR@/%{name}
 
 %changelog
 


### PR DESCRIPTION
rasdaemon rpm package can't build out and report the files should start
from "/".

Update the Makefile by adding "" to folder name and change one
typo.

Signed-off-by: Jason Tian <jason@os.amperecomputing.com>