### PR TITLE
Add ARM processor context info and vendor specific info.

### DIFF
--- a/ras-arm-handler.c
+++ b/ras-arm-handler.c
@@ -20,6 +20,27 @@
 #include "ras-record.h"
 #include "ras-logger.h"
 #include "ras-report.h"
+#include "ras-non-standard-handler.h"
+#include "non-standard-ampere.h"
+
+void display_raw_data(struct trace_seq *s,
+		const uint8_t *buf,
+		uint32_t datalen)
+{
+	int i = 0, line_count = 0;
+
+	trace_seq_printf(s, "  %08x: ", i);
+	while (datalen >= 4) {
+		print_le_hex(s, buf, i);
+		i += 4;
+		datalen -= 4;
+		if (++line_count == 4) {
+			trace_seq_printf(s, "\n  %08x: ", i);
+			line_count = 0;
+		} else
+			trace_seq_printf(s, " ");
+	}
+}
 
 int ras_arm_event_handler(struct trace_seq *s,
 			 struct pevent_record *record,
@@ -30,7 +51,7 @@ int ras_arm_event_handler(struct trace_seq *s,
 	time_t now;
 	struct tm *tm;
 	struct ras_arm_event ev;
-
+	int len = 0;
 	memset(&ev, 0, sizeof(ev));
 
 	/*
@@ -77,6 +98,48 @@ int ras_arm_event_handler(struct trace_seq *s,
 		return -1;
 	ev.psci_state = val;
 	trace_seq_printf(s, "\n psci_state: %d", ev.psci_state);
+
+	if (pevent_get_field_val(s, event, "pei_len", record, &val, 1) < 0)
+		return -1;
+	ev.pei_len = val;
+	trace_seq_printf(s, "\n ARM Processor Err Info data len: %d\n",
+			 ev.pei_len);
+
+	ev.pei_error = pevent_get_field_raw(s, event, "buf", record, &len, 1);
+	if (!ev.pei_error)
+		return -1;
+	display_raw_data(s, ev.pei_error, ev.pei_len);
+
+	if (pevent_get_field_val(s, event, "ctx_len", record, &val, 1) < 0)
+		return -1;
+	ev.ctx_len = val;
+	trace_seq_printf(s, "\n ARM Processor Err Context Info data len: %d\n",
+			 ev.ctx_len);
+
+	ev.ctx_error = pevent_get_field_raw(s, event, "buf1", record, &len, 1);
+	if (!ev.ctx_error)
+		return -1;
+	display_raw_data(s, ev.ctx_error, ev.ctx_len);
+
+	if (pevent_get_field_val(s, event, "oem_len", record, &val, 1) < 0)
+		return -1;
+	ev.oem_len = val;
+	trace_seq_printf(s, "\n Vendor Specific Err Info data len: %d\n",
+			 ev.oem_len);
+
+	ev.vsei_error = pevent_get_field_raw(s, event, "buf2", record, &len, 1);
+	if (!ev.vsei_error)
+		return -1;
+
+#ifdef HAVE_AMP_NS_DECODE
+	//decode ampere specific error
+	decode_amp_payload0_err_regs(NULL, s,
+				(struct amp_payload0_type_sec *)ev.vsei_error);
+
+#else
+	display_raw_data(s, ev.vsei_error, ev.oem_len);
+
+#endif
 
 	/* Insert data into the SGBD */
 #ifdef HAVE_SQLITE3

--- a/ras-arm-handler.h
+++ b/ras-arm-handler.h
@@ -20,5 +20,7 @@
 int ras_arm_event_handler(struct trace_seq *s,
 			 struct pevent_record *record,
 			 struct event_format *event, void *context);
-
+void display_raw_data(struct trace_seq *s,
+		const uint8_t *buf,
+		uint32_t datalen);
 #endif

--- a/ras-record.c
+++ b/ras-record.c
@@ -210,6 +210,9 @@ static const struct db_fields arm_event_fields[] = {
 		{ .name="mpidr",		.type="INTEGER" },
 		{ .name="running_state",	.type="INTEGER" },
 		{ .name="psci_state",		.type="INTEGER" },
+		{ .name="err_info",		.type="BLOB"	},
+		{ .name="context_info",		.type="BLOB"	},
+		{ .name="vendor_info",		.type="BLOB"	},
 };
 
 static const struct db_table_descriptor arm_event_tab = {
@@ -233,6 +236,12 @@ int ras_store_arm_record(struct ras_events *ras, struct ras_arm_event *ev)
 	sqlite3_bind_int64  (priv->stmt_arm_record,  4,  ev->mpidr);
 	sqlite3_bind_int  (priv->stmt_arm_record,  5,  ev->running_state);
 	sqlite3_bind_int  (priv->stmt_arm_record,  6,  ev->psci_state);
+	sqlite3_bind_blob (priv->stmt_arm_record,  7,
+			    ev->pei_error, ev->pei_len, NULL);
+	sqlite3_bind_blob (priv->stmt_arm_record,  8,
+			    ev->ctx_error, ev->ctx_len, NULL);
+	sqlite3_bind_blob (priv->stmt_arm_record,  9,
+			    ev->vsei_error, ev->oem_len, NULL);
 
 	rc = sqlite3_step(priv->stmt_arm_record);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)

--- a/ras-record.h
+++ b/ras-record.h
@@ -77,6 +77,12 @@ struct ras_arm_event {
 	int64_t midr;
 	int32_t running_state;
 	int32_t psci_state;
+	const uint8_t *pei_error;
+	uint32_t pei_len;
+	const uint8_t *ctx_error;
+	uint32_t ctx_len;
+	const uint8_t *vsei_error;
+	uint32_t oem_len;
 };
 
 struct devlink_event {


### PR DESCRIPTION
The trace-cmd don't trace out ARM processor error info
and ARM processor context info, vendor specific info,
which will be updated after kernel 5.11 RC2, update
rasdaemon syncing this change.

Signed-off-by: Jason Tian <jason@os.amperecomputing.com>