### PR TITLE
Log PCIe AER's error source segment and BDF to BMC SEL

### DIFF
--- a/ras-aer-handler.c
+++ b/ras-aer-handler.c
@@ -67,6 +67,9 @@ int ras_aer_event_handler(struct trace_seq *s,
 	struct tm *tm;
 	struct ras_aer_event ev;
 	char buf[BUF_LEN];
+	char ipmi_add_sel[105];
+	uint8_t sel_data[5];
+	int seg, bus, dev, fn;
 
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
@@ -129,15 +132,19 @@ int ras_aer_event_handler(struct trace_seq *s,
 	switch (severity_val) {
 	case HW_EVENT_AER_UNCORRECTED_NON_FATAL:
 		ev.error_type = "Uncorrected (Non-Fatal)";
+		sel_data[0] = 0xca;
 		break;
 	case HW_EVENT_AER_UNCORRECTED_FATAL:
 		ev.error_type = "Uncorrected (Fatal)";
+		sel_data[0] = 0xca;
 		break;
 	case HW_EVENT_AER_CORRECTED:
 		ev.error_type = "Corrected";
+		sel_data[0] = 0xbf;
 		break;
 	default:
 		ev.error_type = "Unknown severity";
+		sel_data[0] = 0xbf;
 	}
 	trace_seq_puts(s, ev.error_type);
 
@@ -149,6 +156,31 @@ int ras_aer_event_handler(struct trace_seq *s,
 #ifdef HAVE_ABRT_REPORT
 	/* Report event to ABRT */
 	ras_report_aer_event(ras, &ev);
+#endif
+
+#ifdef HAVE_AMP_NS_DECODE
+
+	/*Get PCIe AER error source seg/bus/dev/fn and save it into*/
+	/*BMC OEM SEL, ipmitool raw 0x0a 0x44 is IPMI command-Add SEL*/
+	/*entry, please refer IPMI specificaiton chapter 31.6. 0xcd3a*/
+	/*is manufactuer ID(ampere),byte 12 is sensor num(CE is 0xBF,*/
+	/*UE is 0xCA), byte 13~14 is segment number, byte 15 is bus*/
+	/*number, byte 16[7:3] is device number, byte 16[2:0] is */
+	/*function number*/
+
+	sscanf(ev.dev_name, "%x:%x:%x.%x", &seg, &bus, &dev, &fn);
+
+	sel_data[1] = seg & 0xff;
+	sel_data[2] = (seg & 0xff00) >> 8;
+	sel_data[3] = bus;
+	sel_data[4] = (((dev & 0x1f) << 3) | (fn & 0x7));
+
+	sprintf(ipmi_add_sel,
+	  "ipmitool raw 0x0a 0x44 0x00 0x00 0xc0 0x00 0x00 0x00 0x00 0xcd 0x3a 0x04 0xc0 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x",
+	  sel_data[0], sel_data[1], sel_data[2], sel_data[3], sel_data[4]);
+
+	system(ipmi_add_sel);
+
 #endif
 
 	return 0;


### PR DESCRIPTION
This code is specific for Ampere platforms. For OS first error
handling, the PCIe AER error source will be traced out by RAS
daemon and logged in BMC FW with one OEM SEL, the byte 13~14 of
SEL is segment number, the byte 15 is bus number, the byte 16[7:3]
is device number,the byte 16[2:0] is function number.CE error's
sensor num is CE_PCIE_IErr(0xBF) and UE error's sensor num is
UE_PCIE_IErr(0xCA).

Signed-off-by: Jason Tian <jason@os.amperecomputing.com>