### PR TITLE
rasdaemon: fix memory leak in parse_ras_data

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -317,6 +317,7 @@ static void parse_ras_data(struct pthread_data *pdata, struct kbuffer *kbuf,
 	trace_seq_do_printf(&s);
 	printf("\n");
 	fflush(stdout);
+	trace_seq_destroy(&s);
 }
 
 static int get_num_cpus(struct ras_events *ras)


### PR DESCRIPTION
parse_ras_data() is calling trace_seq_init() which allocates a buffer,
but never calls the corresponding trace_seq_destroy() to free it causing
us to leak memory.

Signed-off-by: Josh Hunt <johunt@akamai.com>