### PR TITLE
ras-record: Create RASSTATEDIR at runtime instead of install time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,7 +89,6 @@ upload:
 
 # custom target
 install-data-local:
-	$(install_sh) -d "$(DESTDIR)@RASSTATEDIR@"
 	$(install_sh) -d "$(DESTDIR)@sysconfdir@/ras/dimm_labels.d"
 if WITH_MEMORY_CE_PFA
 	$(install_sh) @abs_srcdir@/misc/rasdaemon.env "$(DESTDIR)@SYSCONFDEFDIR@/rasdaemon"


### PR DESCRIPTION
Package managers such as Nix and Guix force installation into an
isolated directory hierarchy. Furthermore, said hierarchy becomes
readonly after the install has completed, rendering any
<hierarchy>/var/lib/rasdaemon/ directory effectively useless.

In addition to being standard practice, creating RASSTATEDIR when
necessary at runtime fixes the above use cases.