### PR TITLE
Added label for ASUS PRIME X570-PRO

### DIFF
--- a/labels/asus
+++ b/labels/asus
@@ -1,0 +1,20 @@
+# RASDAEMON Motherboard DIMM labels Database file.
+#
+#  Vendor-name and model-name are found from the program 'dmidecode'
+#  labels are found from the silk screen on the motherboard.
+#
+#Vendor: <vendor-name>
+#  Product: <product-name>
+#  Model: <model-name>
+#    <label>: <mc>.<top>.<mid>.<low>
+#
+#
+#Vendor: <vendor-name>
+#  Model: <model-name>
+#    <label>: <mc>.<row>.<channel>
+#
+
+Vendor: ASUSTeK COMPUTER INC.
+  Model: PRIME X570-PRO
+    DIMM_A1:  0.0.1, 0.1.1;    DIMM_A2:   0.2.1, 0.3.1;
+    DIMM_B1:  0.0.0, 0.1.0;    DIMM_B2:   0.2.0, 0.3.0;


### PR DESCRIPTION
#ras-mc-ctl --mainboard
ras-mc-ctl: mainboard: ASUSTeK COMPUTER INC. model PRIME X570-PRO

Installed DIMM_A1:
#ras-mc-ctl --error-count
Label                   CE      UE
mc#0csrow#0channel#1    0       0
mc#0csrow#1channel#1    0       0

Installed DIMM_A2:
#ras-mc-ctl --error-count
Label                   CE      UE
mc#0csrow#3channel#1    0       0
mc#0csrow#2channel#1    0       0

Installed DIMM_B1:
#ras-mc-ctl --error-count
Label                   CE      UE
mc#0csrow#1channel#0    0       0
mc#0csrow#0channel#0    0       0

Installed DIMM_B2:
#ras-mc-ctl --error-count
Label                   CE      UE
mc#0csrow#2channel#0    0       0
mc#0csrow#3channel#0    0       0


Test with 2 DIMMs:

#ras-mc-ctl --print-labels
LOCATION                            CONFIGURED LABEL     SYSFS CONTENTS      
                                    DIMM_B1              0:0:0 missing       
                                    DIMM_A1              0:0:1 missing       
                                    DIMM_B1              0:1:0 missing       
                                    DIMM_A1              0:1:1 missing       
mc0 csrow 2 channel 0               DIMM_B2              DIMM_B2             
mc0 csrow 2 channel 1               DIMM_A2              DIMM_A2             
mc0 csrow 3 channel 0               DIMM_B2              DIMM_B2             
mc0 csrow 3 channel 1               DIMM_A2              DIMM_A2