### PR TITLE
configure.ac: fix SYSCONFDEFDIR default value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ AC_SUBST([RASSTATEDIR])
 AC_ARG_WITH(sysconfdefdir,
     AC_HELP_STRING([--with-sysconfdefdir=DIR], [rasdaemon environment file dir]),
     [SYSCONFDEFDIR=$withval],
-    ["/etc/sysconfig"])
+    [SYSCONFDEFDIR=/etc/sysconfig])
 AC_SUBST([SYSCONFDEFDIR])
 
 AC_DEFINE([RAS_DB_FNAME], ["ras-mc_event.db"], [ras events database])


### PR DESCRIPTION
`configure.ac` was using `AC_ARG_WITH` incorrectly, yielding a generated configure script like:

    # Check whether --with-sysconfdefdir was given.
    if test "${with_sysconfdefdir+set}" = set; then :
      withval=$with_sysconfdefdir; SYSCONFDEFDIR=$withval
    else
      "/etc/sysconfig"
    fi

This commit fixes the default case so that the `SYSCONFDEFDIR` variable is assigned the value `/etc/sysconfig` rather than trying to execute `"/etc/sysconfig"` as a command.

For reference, the previous code emits the following error at configure-time:

    ./configure: line 12606: /etc/sysconfig: Is a directory