### PR TITLE
Supermicro labels

### DIFF
--- a/labels/supermicro
+++ b/labels/supermicro
@@ -18,17 +18,17 @@ Vendor: Supermicro
     DIMMA1: 0.0.0;    DIMMA2: 0.0.1;
     DIMMB1: 0.1.0;    DIMMB2: 0.1.1;
 
-	Product: X10SRA-F
-		DIMMA1: 0.0.0
-		DIMMA2: 0.0.1
-		DIMMB1: 0.1.0
-		DIMMB2: 0.1.1
-		DIMMC1: 1.0.0
-		DIMMC2: 1.0.1
-		DIMMD1: 1.1.0
-		DIMMD2: 1.1.1
+	Model: X10SRA-F
+		DIMMA1: 0.0.0;
+		DIMMA2: 0.0.1;
+		DIMMB1: 0.1.0;
+		DIMMB2: 0.1.1;
+		DIMMC1: 1.0.0;
+		DIMMC2: 1.0.1;
+		DIMMD1: 1.1.0;
+		DIMMD2: 1.1.1;
 
-	Product: H8DGU
+	Model: H8DGU
 		P1_DIMM1A: 0.2.0;
 		P1_DIMM1A: 0.3.0;
 		P2_DIMM1A: 3.2.0;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -69,7 +69,7 @@ Vendor: Supermicro
 		P2_DIMM4B: 2.0.1;
 		P2_DIMM4B: 2.1.1;
   
-  Model: X11DPH-i
+  Model: X11DPH-i, X11DPH-T, X11DPH-TQ
     P1-DIMMA1: 0.0.0;    P1-DIMMA2: 0.0.1;
     P1-DIMMB1: 0.1.0;
     P1-DIMMC1: 0.2.0;
@@ -92,3 +92,17 @@ Vendor: Supermicro
     P2-DIMMF1: 1.1.0;    P2-DIMMF2: 1.1.1;
     P2-DIMMG1: 1.2.0;    P2-DIMMG2: 1.2.1;
     P2-DIMMH1: 1.3.0;    P2-DIMMH2: 1.3.1;
+  
+  Model: X11DDW-NT, X11DDW-L
+    P1-DIMMA1: 0.0.0;
+    P1-DIMMB1: 0.1.0;
+    P1-DIMMC1: 0.2.0;
+    P1-DIMMD1: 1.0.0;
+    P1-DIMME1: 1.1.0;
+    P1-DIMMF1: 1.2.0;
+    P2-DIMMA1: 2.0.0;
+    P2-DIMMB1: 2.1.0;
+    P2-DIMMC1: 2.2.0;
+    P2-DIMMD1: 3.0.0;
+    P2-DIMME1: 3.1.0;
+    P2-DIMMF1: 3.2.0;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -82,3 +82,13 @@ Vendor: Supermicro
     P2-DIMMD1: 3.0.0;    P2-DIMMD2: 3.0.1;
     P2-DIMME1: 3.1.0;
     P2-DIMMF1: 3.2.0;
+    
+  Model: X10DRI, X10DRI-T
+    P1-DIMMA1: 0.0.0;    P1-DIMMA2: 0.0.1;
+    P1-DIMMB1: 0.1.0;    P1-DIMMB2: 0.1.1;
+    P1-DIMMC1: 0.2.0;    P1-DIMMC2: 0.2.1;
+    P1-DIMMD1: 0.3.0;    P1-DIMMD2: 0.3.1;
+    P2-DIMME1: 1.0.0;    P2-DIMME2: 1.0.1;
+    P2-DIMMF1: 1.1.0;    P2-DIMMF2: 1.1.1;
+    P2-DIMMG1: 1.2.0;    P2-DIMMG2: 1.2.1;
+    P2-DIMMH1: 1.3.0;    P2-DIMMH2: 1.3.1;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -106,3 +106,13 @@ Vendor: Supermicro
     P2-DIMMD1: 3.0.0;
     P2-DIMME1: 3.1.0;
     P2-DIMMF1: 3.2.0;
+    
+  Model: B1DRi
+    P1_DIMMA1: 0.0.0;
+    P1_DIMMB1: 0.1.0;
+    P1_DIMMC1: 0.2.0;
+    P1_DIMMD1: 0.3.0;
+    P2_DIMME1: 1.0.0;
+    P2_DIMMF1: 1.1.0;
+    P2_DIMMG1: 1.2.0;
+    P2_DIMMH1: 1.3.0;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -10,11 +10,7 @@
 #
 
 Vendor: Supermicro
-  Model: A2SDi-8C-HLN4F
-    DIMMA1: 0.0.0;    DIMMA2: 0.0.1;
-    DIMMB1: 0.1.0;    DIMMB2: 0.1.1;
-
-  Model: A2SDi-8C+-HLN4F
+  Model: A2SDi-8C-HLN4F, A2SDi-8C+-HLN4F
     DIMMA1: 0.0.0;    DIMMA2: 0.0.1;
     DIMMB1: 0.1.0;    DIMMB2: 0.1.1;
 
@@ -116,3 +112,7 @@ Vendor: Supermicro
     P2_DIMMF1: 1.1.0;
     P2_DIMMG1: 1.2.0;
     P2_DIMMH1: 1.3.0;
+  
+  Model: X11SCA, X11SCA-F
+    DIMMA1:  0.0.0, 0.1.0;    DIMMA2:   0.2.0, 0.3.0;
+    DIMMB1:  0.0.1, 0.1.1;    DIMMB2:   0.2.1, 0.3.1;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -88,6 +88,16 @@ Vendor: Supermicro
     P2-DIMMF1: 1.1.0;    P2-DIMMF2: 1.1.1;
     P2-DIMMG1: 1.2.0;    P2-DIMMG2: 1.2.1;
     P2-DIMMH1: 1.3.0;    P2-DIMMH2: 1.3.1;
+
+  Model: X10DRL-i
+    P1-DIMMA1: 0.0.0;
+    P1-DIMMB1: 0.1.0;
+    P1-DIMMC1: 0.2.0;
+    P1-DIMMD1: 0.3.0;
+    P2-DIMME1: 1.0.0;
+    P2-DIMMF1: 1.1.0;
+    P2-DIMMG1: 1.2.0;
+    P2-DIMMH1: 1.3.0;
   
   Model: X11DDW-NT, X11DDW-L
     P1-DIMMA1: 0.0.0;
@@ -102,6 +112,14 @@ Vendor: Supermicro
     P2-DIMMD1: 3.0.0;
     P2-DIMME1: 3.1.0;
     P2-DIMMF1: 3.2.0;
+  
+  Model: X11SPM-F, X11SPM-TF, X11SPM-TPF
+    DIMMA1: 0.0.0;
+    DIMMB1: 0.1.0;
+    DIMMC1: 0.2.0;
+    DIMMD1: 1.0.0;
+    DIMME1: 1.1.0;
+    DIMMF1: 1.2.0;
     
   Model: B1DRi
     P1_DIMMA1: 0.0.0;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -68,3 +68,17 @@ Vendor: Supermicro
 		P1_DIMM4B: 1.1.1;
 		P2_DIMM4B: 2.0.1;
 		P2_DIMM4B: 2.1.1;
+  
+  Model: X11DPH-i
+    P1-DIMMA1: 0.0.0;    P1-DIMMA2: 0.0.1;
+    P1-DIMMB1: 0.1.0;
+    P1-DIMMC1: 0.2.0;
+    P1-DIMMD1: 1.0.0;    P1-DIMMD2: 1.0.1;
+    P1-DIMME1: 1.1.0;
+    P1-DIMMF1: 1.2.0;
+    P2-DIMMA1: 2.0.0;    P2-DIMMA2: 2.0.1;
+    P2-DIMMB1: 2.1.0;
+    P2-DIMMC1: 2.2.0;
+    P2-DIMMD1: 3.0.0;    P2-DIMMD2: 3.0.1;
+    P2-DIMME1: 3.1.0;
+    P2-DIMMF1: 3.2.0;

--- a/labels/supermicro
+++ b/labels/supermicro
@@ -134,3 +134,9 @@ Vendor: Supermicro
   Model: X11SCA, X11SCA-F
     DIMMA1:  0.0.0, 0.1.0;    DIMMA2:   0.2.0, 0.3.0;
     DIMMB1:  0.0.1, 0.1.1;    DIMMB2:   0.2.1, 0.3.1;
+    
+  Model: X11SCW-F
+    DIMMA1: 0.1.0;
+    DIMMA2: 0.0.0;
+    DIMMB1: 0.1.1;
+    DIMMB2: 0.0.1;


### PR DESCRIPTION
I have added and tested some DIMM labels for Supermicro motherboards:  X11DPH-x, X10DRI, X11DDW-x, B1DRi, X11SCA.