### PR TITLE
rasdaemon: fix compile against musl libc

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -18,6 +18,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fix the following compile errors that occurs when building against musl:

ras-events.c: In function 'read_ras_event_all_cpus':
ras-events.c:366:16: error: 'PATH_MAX' undeclared (first use in this function)
  366 |  char pipe_raw[PATH_MAX];
      |                ^~~~~~~~

ras-events.c: In function 'handle_ras_events_cpu':
ras-events.c:564:16: error: 'PATH_MAX' undeclared (first use in this function)
  564 |  char pipe_raw[PATH_MAX];
      |

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>