### PR TITLE
add labels for asrock x570 motherboard

### DIFF
--- a/labels/asrock
+++ b/labels/asrock
@@ -1,0 +1,20 @@
+# RASDAEMON Motherboard DIMM labels Database file.
+#
+#  Vendor-name and model-name are found from the program 'dmidecode'
+#  labels are found from the silk screen on the motherboard.
+#
+#Vendor: <vendor-name>
+#  Product: <product-name>
+#  Model: <model-name>
+#    <label>: <mc>.<top>.<mid>.<low>
+#
+#
+#Vendor: <vendor-name>
+#  Model: <model-name>
+#    <label>: <mc>.<row>.<channel>
+#
+
+Vendor: ASRock
+  Model: X570 Phantom Gaming X
+    DIMM_A1:  0.0.1, 0.1.1;    DIMM_A2:   0.2.1, 0.3.1;
+    DIMM_B1:  0.0.0, 0.1.0;    DIMM_B2:   0.2.0, 0.3.0;


### PR DESCRIPTION
These are the Dimm Labels for the ASRock X570 Phantom Gaming X motherboard.  
I probed these in the recommended way, although as I just discovered, they are identical to the Asus X570-Pro.

Signed-off-by: Steven Johnson strntydog@gmail.com