### PR TITLE
rasdaemon.service.in: comment out syslog.target

### DIFF
--- a/misc/rasdaemon.service.in
+++ b/misc/rasdaemon.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=RAS daemon to log the RAS events
-After=syslog.target
+# only needed when not running in foreground (--foreground | -f)
+#After=syslog.target
 
 [Service]
 EnvironmentFile=@SYSCONFDEFDIR@/rasdaemon


### PR DESCRIPTION
syslog seems to only used when the daemon runs in backround mode
(according to https://github.com/mchehab/rasdaemon/blob/a2818bca232f167ac68cfbf412602d4902c4ae16/README#L151)
that service is configured to run in foreground mode
(it has been since it was checked in in 79abfdf0d8545dd6c33301484e9f47c8439d2522)

and syslog was deprecated shortly after this line was committed
https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L61