### PR TITLE
rasdaemon: use the new block_rq_error tracepoint

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -28,6 +28,7 @@
 #include <sys/poll.h>
 #include <signal.h>
 #include <sys/signalfd.h>
+#include <linux/version.h>
 #include "libtrace/kbuffer.h"
 #include "libtrace/event-parse.h"
 #include "ras-mc-handler.h"
@@ -230,7 +231,11 @@ int toggle_ras_mc_event(int enable)
 #endif
 
 #ifdef HAVE_DISKERROR
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+	rc |= __toggle_ras_mc_event(ras, "block", "block_rq_error", enable);
+#else
 	rc |= __toggle_ras_mc_event(ras, "block", "block_rq_complete", enable);
+#endif
 #endif
 
 #ifdef HAVE_MEMORY_FAILURE
@@ -242,6 +247,7 @@ free_ras:
 	return rc;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
 /*
  * Set kernel filter. libtrace doesn't provide an API for setting filters
  * in kernel, we have to implement it here.
@@ -273,6 +279,7 @@ static int filter_ras_mc_event(struct ras_events *ras, char *group, char *event,
 
 	return 0;
 }
+#endif
 
 /*
  * Tracing read code
@@ -902,6 +909,16 @@ int handle_ras_events(int record_events)
 #endif
 
 #ifdef HAVE_DISKERROR
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+	rc = add_event_handler(ras, pevent, page_size, "block",
+			       "block_rq_error", ras_diskerror_event_handler,
+				NULL, DISKERROR_EVENT);
+	if (!rc)
+		num_events++;
+	else
+		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
+		    "block", "block_rq_error");
+#else
 	rc = filter_ras_mc_event(ras, "block", "block_rq_complete", "error != 0");
 	if (!rc) {
 		rc = add_event_handler(ras, pevent, page_size, "block",
@@ -913,6 +930,7 @@ int handle_ras_events(int record_events)
 			log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 			    "block", "block_rq_complete");
 	}
+#endif
 #endif
 
 #ifdef HAVE_MEMORY_FAILURE

--- a/ras-record.c
+++ b/ras-record.c
@@ -456,7 +456,7 @@ int ras_store_devlink_event(struct ras_events *ras, struct devlink_event *ev)
 #endif
 
 /*
- * Table and functions to handle block:block_rq_complete
+ * Table and functions to handle block:block_rq_{complete|error}
  */
 
 #ifdef HAVE_DISKERROR


### PR DESCRIPTION
Since Linux 5.18-rc1 a new block tracepoint called block_rq_error is
available for tracing disk error events dedicatedly.  Currently
rasdaemon is using block_rq_complete which also traces successful cases.
It incurs excessive tracing logs and somehow overhead since the event is
triggered quite often.

Use the new tracepoint for disk error reporting, and the new trace point
has the same format as block_rq_complete.

Signed-off-by: Yang Shi <shy828301@gmail.com>