### PR TITLE
ras-events: quit dead loop in read_ras_event when kbuf data is broken

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -512,6 +512,11 @@ static int read_ras_event_all_cpus(struct pthread_data *pdata,
 				kbuffer_load_subbuffer(kbuf, page);
 
 				while ((data = kbuffer_read_event(kbuf, &time_stamp))) {
+					if (kbuffer_curr_size(kbuf) < 0) {
+						log(TERM, LOG_ERR, "invalid kbuf data, discard\n");
+						break;
+					}
+
 					parse_ras_data(&pdata[i],
 						       kbuf, data, time_stamp);
 


### PR DESCRIPTION
when kbuf data is broken, kbuffer_next_event() may move kbuf->index back to
the current kbuf->index position, causing dead loop.

In this situation, rasdaemon will repeatedly parse an invalid event, and
print warning like "ug! negative record size -8!", pushing cpu utilization
rate to 100%.

when kbuf data is broken, discard current page and continue reading next page
kbuf.
