### PR TITLE
Fix return value type issue, some clean-up and add handling of run-time errors in ras-mc-ctl.in

### DIFF
--- a/non-standard-hisi_hip08.c
+++ b/non-standard-hisi_hip08.c
@@ -1029,7 +1029,7 @@ static struct ras_ns_ev_decoder hip08_ns_ev_decoder[] = {
 
 static void __attribute__((constructor)) hip08_init(void)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(hip08_ns_ev_decoder); i++)
 		register_ns_ev_decoder(&hip08_ns_ev_decoder[i]);

--- a/non-standard-hisilicon.c
+++ b/non-standard-hisilicon.c
@@ -366,7 +366,7 @@ static int decode_hisi_common_section(struct ras_events *ras,
 	trace_seq_printf(s, "%s\n", hevent.error_msg);
 
 	if (err->val_bits & BIT(HISI_COMMON_VALID_REG_ARRAY_SIZE) && err->reg_array_size > 0) {
-		int i;
+		unsigned int i;
 
 		trace_seq_printf(s, "Register Dump:\n");
 		for (i = 0; i < err->reg_array_size / sizeof(uint32_t); i++) {
@@ -398,7 +398,7 @@ static struct ras_ns_ev_decoder hisi_section_ns_ev_decoder[]  = {
 
 static void __attribute__((constructor)) hisi_ns_init(void)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(hisi_section_ns_ev_decoder); i++)
 		register_ns_ev_decoder(&hisi_section_ns_ev_decoder[i]);

--- a/non-standard-hisilicon.c
+++ b/non-standard-hisilicon.c
@@ -370,9 +370,9 @@ static int decode_hisi_common_section(struct ras_events *ras,
 
 		trace_seq_printf(s, "Register Dump:\n");
 		for (i = 0; i < err->reg_array_size / sizeof(uint32_t); i++) {
-			trace_seq_printf(s, "reg%02d=0x%08x\n", i,
+			trace_seq_printf(s, "reg%02u=0x%08x\n", i,
 					 err->reg_array[i]);
-			HISI_SNPRINTF(hevent.reg_msg, "reg%02d=0x%08x",
+			HISI_SNPRINTF(hevent.reg_msg, "reg%02u=0x%08x",
 				      i, err->reg_array[i]);
 		}
 	}

--- a/ras-diskerror-handler.c
+++ b/ras-diskerror-handler.c
@@ -52,7 +52,7 @@ static const struct {
 
 static const char *get_blk_error(int err)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(blk_errors); i++)
 		if (blk_errors[i].error == err)

--- a/ras-memory-failure-handler.c
+++ b/ras-memory-failure-handler.c
@@ -99,7 +99,7 @@ static const struct {
 
 static const char *get_page_type(int page_type)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(mf_page_type); i++)
 		if (mf_page_type[i].type == page_type)
@@ -110,7 +110,7 @@ static const char *get_page_type(int page_type)
 
 static const char *get_action_result(int result)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(mf_action_result); i++)
 		if (mf_action_result[i].result == result)

--- a/ras-memory-failure-handler.c
+++ b/ras-memory-failure-handler.c
@@ -15,11 +15,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <traceevent/kbuffer.h>
-#include "ras-memory-failure-handler.h"
 #include "ras-record.h"
 #include "ras-logger.h"
 #include "ras-report.h"
+#include "ras-memory-failure-handler.h"
 
 /* Memory failure - various types of pages */
 enum mf_action_page_type {

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -34,6 +34,7 @@ use File::Basename;
 use File::Find;
 use Getopt::Long;
 use POSIX;
+use Try::Tiny;
 
 my $dbname      = "@RASSTATEDIR@/@RAS_DB_FNAME@";
 my $prefix      = "@prefix@";
@@ -1562,81 +1563,115 @@ sub vendor_errors_summary
     }
 
     my $dbh = DBI->connect("dbi:SQLite:dbname=$dbname", "", "", {});
+    # Disable the DBI automatic error log
+    $dbh->{PrintError} = 0;
 
     # HiSilicon KunPeng9xx errors
     if ($platform_id eq HISILICON_KUNPENG_9XX) {
-	$found_platform = 1;
-        $query = "select err_severity, module_id, count(*) from hip08_oem_type1_event_v2$conf{opt}{since} group by err_severity, module_id";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($err_severity, $module_id, $count));
-        $out = "";
-        $err_sev = "";
-        while($query_handle->fetch()) {
-            if ($err_severity ne $err_sev) {
-                $out .= "$err_severity errors:\n";
-                $err_sev = $err_severity;
+        $found_platform = 1;
+        try {
+            $query = "select err_severity, module_id, count(*) from hip08_oem_type1_event_v2$conf{opt}{since} group by err_severity, module_id";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($err_severity, $module_id, $count));
+            $out = "";
+            $err_sev = "";
+            while($query_handle->fetch()) {
+                if ($err_severity ne $err_sev) {
+                    $out .= "$err_severity errors:\n";
+                    $err_sev = $err_severity;
+                }
+                $out .= "\t$module_id: $count\n";
             }
-            $out .= "\t$module_id: $count\n";
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx OEM type1 error events summary:\n$out\n";
-        }
-        $query_handle->finish;
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx OEM type1 error events summary:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx OEM type1 errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx OEM type1 errors\n\n";
+            }
+        };
 
-        $query = "select err_severity, module_id, count(*) from hip08_oem_type2_event_v2$conf{opt}{since} group by err_severity, module_id";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($err_severity, $module_id, $count));
-        $out = "";
-        $err_sev = "";
-        while($query_handle->fetch()) {
-            if ($err_severity ne $err_sev) {
-                $out .= "$err_severity errors:\n";
-                $err_sev = $err_severity;
+        try {
+	    $query = "select err_severity, module_id, count(*) from hip08_oem_type2_event_v2$conf{opt}{since} group by err_severity, module_id";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($err_severity, $module_id, $count));
+            $out = "";
+            $err_sev = "";
+            while($query_handle->fetch()) {
+                if ($err_severity ne $err_sev) {
+                    $out .= "$err_severity errors:\n";
+                    $err_sev = $err_severity;
+                }
+                $out .= "\t$module_id: $count\n";
             }
-            $out .= "\t$module_id: $count\n";
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx OEM type2 error events summary:\n$out\n";
-        }
-        $query_handle->finish;
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx OEM type2 error events summary:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx OEM type2 errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx OEM type2 errors\n\n";
+            }
+        };
 
-        $query = "select err_severity, sub_module_id, count(*) from hip08_pcie_local_event_v2$conf{opt}{since} group by err_severity, sub_module_id";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($err_severity, $sub_module_id, $count));
-        $out = "";
-        $err_sev = "";
-        while($query_handle->fetch()) {
-            if ($err_severity ne $err_sev) {
-                $out .= "$err_severity errors:\n";
-                $err_sev = $err_severity;
+        try {
+            $query = "select err_severity, sub_module_id, count(*) from hip08_pcie_local_event_v2$conf{opt}{since} group by err_severity, sub_module_id";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($err_severity, $sub_module_id, $count));
+            $out = "";
+            $err_sev = "";
+            while($query_handle->fetch()) {
+                if ($err_severity ne $err_sev) {
+                    $out .= "$err_severity errors:\n";
+                    $err_sev = $err_severity;
+                }
+                $out .= "\t$sub_module_id: $count\n";
             }
-            $out .= "\t$sub_module_id: $count\n";
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx PCIe controller error events summary:\n$out\n";
-        }
-        $query_handle->finish;
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx PCIe controller error events summary:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx PCIe controller errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx PCIe controller errors\n\n";
+            }
+        };
 
-        $query = "select err_severity, module_id, count(*) from hisi_common_section_v2$conf{opt}{since} group by err_severity, module_id";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($err_severity, $module_id, $count));
-        $out = "";
-        $err_sev = "";
-        while($query_handle->fetch()) {
-            if ($err_severity ne $err_sev) {
-                $out .= "$err_severity errors:\n";
-                $err_sev = $err_severity;
+        try {
+            $query = "select err_severity, module_id, count(*) from hisi_common_section_v2$conf{opt}{since} group by err_severity, module_id";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($err_severity, $module_id, $count));
+            $out = "";
+            $err_sev = "";
+            while($query_handle->fetch()) {
+                if ($err_severity ne $err_sev) {
+                    $out .= "$err_severity errors:\n";
+                    $err_sev = $err_severity;
+                }
+                $out .= "\t$module_id: $count\n";
             }
-            $out .= "\t$module_id: $count\n";
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx common error events summary:\n$out\n";
-        }
-        $query_handle->finish;
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx common error events summary:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx common errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx common errors\n\n";
+            }
+        };
     }
 
     if ($platform_id && !($found_platform)) {
@@ -1670,117 +1705,151 @@ sub vendor_errors
     }
 
     my $dbh = DBI->connect("dbi:SQLite:dbname=$dbname", "", "", {});
+    # Disable the DBI automatic error log
+    $dbh->{PrintError} = 0;
 
     # HiSilicon KunPeng9xx errors
     if ($platform_id eq HISILICON_KUNPENG_9XX) {
-	$found_platform = 1;
-        $query = "select id, timestamp, version, soc_id, socket_id, nimbus_id, module_id, sub_module_id, err_severity, regs_dump from hip08_oem_type1_event_v2$conf{opt}{since} order by id, module_id, err_severity";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $nimbus_id, $module_id, $sub_module_id, $err_severity, $regs));
-        $out = "";
-        while($query_handle->fetch()) {
-            if ($module eq 0 || ($module_id && uc($module) eq uc($module_id))) {
-                $out .= "$id. $timestamp Error Info: ";
-                $out .= "version=$version, ";
-                $out .= "soc_id=$soc_id, " if ($soc_id);
-                $out .= "socket_id=$socket_id, " if ($socket_id);
-                $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
-                $out .= "module_id=$module_id, " if ($module_id);
-                $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
-                $out .= "err_severity=$err_severity, " if ($err_severity);
-                $out .= "Error Registers: $regs " if ($regs);
-                $out .= "\n\n";
-                $found_module = 1;
-	    }
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx OEM type1 error events:\n$out\n";
-        }
-        $query_handle->finish;
+        $found_platform = 1;
+        try {
+	    $query = "select id, timestamp, version, soc_id, socket_id, nimbus_id, module_id, sub_module_id, err_severity, regs_dump from hip08_oem_type1_event_v2$conf{opt}{since} order by id, module_id, err_severity";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $nimbus_id, $module_id, $sub_module_id, $err_severity, $regs));
+            $out = "";
+            while($query_handle->fetch()) {
+                if ($module eq 0 || ($module_id && uc($module) eq uc($module_id))) {
+                    $out .= "$id. $timestamp Error Info: ";
+                    $out .= "version=$version, ";
+                    $out .= "soc_id=$soc_id, " if ($soc_id);
+                    $out .= "socket_id=$socket_id, " if ($socket_id);
+                    $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
+                    $out .= "module_id=$module_id, " if ($module_id);
+                    $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
+                    $out .= "err_severity=$err_severity, " if ($err_severity);
+                    $out .= "Error Registers: $regs " if ($regs);
+                    $out .= "\n\n";
+                    $found_module = 1;
+	        }
+            }
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx OEM type1 error events:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx OEM type1 errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx OEM type1 errors\n\n";
+            }
+        };
 
-        $query = "select id, timestamp, version, soc_id, socket_id, nimbus_id, module_id, sub_module_id, err_severity, regs_dump from hip08_oem_type2_event_v2$conf{opt}{since} order by id, module_id, err_severity";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $nimbus_id, $module_id, $sub_module_id, $err_severity, $regs));
-        $out = "";
-        while($query_handle->fetch()) {
-            if ($module eq 0 || ($module_id && uc($module) eq uc($module_id))) {
-                $out .= "$id. $timestamp Error Info: ";
-                $out .= "version=$version, ";
-                $out .= "soc_id=$soc_id, " if ($soc_id);
-                $out .= "socket_id=$socket_id, " if ($socket_id);
-                $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
-                $out .= "module_id=$module_id, " if ($module_id);
-                $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
-                $out .= "err_severity=$err_severity, " if ($err_severity);
-                $out .= "Error Registers: $regs " if ($regs);
-                $out .= "\n\n";
-                $found_module = 1;
-	    }
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx OEM type2 error events:\n$out\n";
-        }
-        $query_handle->finish;
+        try {
+            $query = "select id, timestamp, version, soc_id, socket_id, nimbus_id, module_id, sub_module_id, err_severity, regs_dump from hip08_oem_type2_event_v2$conf{opt}{since} order by id, module_id, err_severity";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $nimbus_id, $module_id, $sub_module_id, $err_severity, $regs));
+            $out = "";
+            while($query_handle->fetch()) {
+                if ($module eq 0 || ($module_id && uc($module) eq uc($module_id))) {
+                    $out .= "$id. $timestamp Error Info: ";
+                    $out .= "version=$version, ";
+                    $out .= "soc_id=$soc_id, " if ($soc_id);
+                    $out .= "socket_id=$socket_id, " if ($socket_id);
+                    $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
+                    $out .= "module_id=$module_id, " if ($module_id);
+                    $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
+                    $out .= "err_severity=$err_severity, " if ($err_severity);
+                    $out .= "Error Registers: $regs " if ($regs);
+                    $out .= "\n\n";
+                    $found_module = 1;
+	        }
+            }
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx OEM type2 error events:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx OEM type2 errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx OEM type2 errors\n\n";
+            }
+        };
 
-        $query = "select id, timestamp, version, soc_id, socket_id, nimbus_id, sub_module_id, core_id, port_id, err_severity, err_type, regs_dump from hip08_pcie_local_event_v2$conf{opt}{since} order by id, sub_module_id, err_severity";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $nimbus_id, $sub_module_id, $core_id, $port_id, $err_severity, $err_type, $regs));
-        $out = "";
-        while($query_handle->fetch()) {
-            if ($module eq 0 || ($sub_module_id && uc($module) eq uc($sub_module_id))) {
-                $out .= "$id. $timestamp Error Info: ";
-                $out .= "version=$version, ";
-                $out .= "soc_id=$soc_id, " if ($soc_id);
-                $out .= "socket_id=$socket_id, " if ($socket_id);
-                $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
-                $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
-                $out .= "core_id=$core_id, " if ($core_id);
-                $out .= "port_id=$port_id, " if ($port_id);
-                $out .= "err_severity=$err_severity, " if ($err_severity);
-                $out .= "err_type=$err_type, " if ($err_type);
-                $out .= "Error Registers: $regs " if ($regs);
-                $out .= "\n\n";
-                $found_module = 1;
-	    }
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx PCIe controller error events:\n$out\n";
-        }
-        $query_handle->finish;
+        try {
+            $query = "select id, timestamp, version, soc_id, socket_id, nimbus_id, sub_module_id, core_id, port_id, err_severity, err_type, regs_dump from hip08_pcie_local_event_v2$conf{opt}{since} order by id, sub_module_id, err_severity";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $nimbus_id, $sub_module_id, $core_id, $port_id, $err_severity, $err_type, $regs));
+            $out = "";
+            while($query_handle->fetch()) {
+                if ($module eq 0 || ($sub_module_id && uc($module) eq uc($sub_module_id))) {
+                    $out .= "$id. $timestamp Error Info: ";
+                    $out .= "version=$version, ";
+                    $out .= "soc_id=$soc_id, " if ($soc_id);
+                    $out .= "socket_id=$socket_id, " if ($socket_id);
+                    $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
+                    $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
+                    $out .= "core_id=$core_id, " if ($core_id);
+                    $out .= "port_id=$port_id, " if ($port_id);
+                    $out .= "err_severity=$err_severity, " if ($err_severity);
+                    $out .= "err_type=$err_type, " if ($err_type);
+                    $out .= "Error Registers: $regs " if ($regs);
+                    $out .= "\n\n";
+                    $found_module = 1;
+	        }
+            }
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx PCIe controller error events:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx PCIe controller errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx PCIe controller errors\n\n";
+            }
+        };
 
-        $query = "select id, timestamp, version, soc_id, socket_id, totem_id, nimbus_id, sub_system_id, module_id, sub_module_id, core_id, port_id, err_type, pcie_info, err_severity, regs_dump from hisi_common_section_v2$conf{opt}{since} order by id, module_id, err_severity";
-        $query_handle = $dbh->prepare($query);
-        $query_handle->execute();
-        $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $totem_id, $nimbus_id, $sub_system_id, $module_id, $sub_module_id, $core_id, $port_id, $err_type, $pcie_info, $err_severity, $regs));
-        $out = "";
-        while($query_handle->fetch()) {
-            if ($module eq 0 || ($module_id && uc($module) eq uc($module_id))) {
-                $out .= "$id. $timestamp Error Info: ";
-                $out .= "version=$version, ";
-                $out .= "soc_id=$soc_id, " if ($soc_id);
-                $out .= "socket_id=$socket_id, " if ($socket_id);
-                $out .= "totem_id=$totem_id, " if ($totem_id);
-                $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
-                $out .= "sub_system_id=$sub_system_id, " if ($sub_system_id);
-                $out .= "module_id=$module_id, " if ($module_id);
-                $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
-                $out .= "core_id=$core_id, " if ($core_id);
-                $out .= "port_id=$port_id, " if ($port_id);
-                $out .= "err_type=$err_type, " if ($err_type);
-                $out .= "pcie_info=$pcie_info, " if ($pcie_info);
-                $out .= "err_severity=$err_severity, " if ($err_severity);
-                $out .= "Error Registers: $regs" if ($regs);
-                $out .= "\n\n";
-                $found_module = 1;
-	    }
-        }
-        if ($out ne "") {
-            print "HiSilicon KunPeng9xx common error events:\n$out\n";
-        }
-        $query_handle->finish;
+        try {
+            $query = "select id, timestamp, version, soc_id, socket_id, totem_id, nimbus_id, sub_system_id, module_id, sub_module_id, core_id, port_id, err_type, pcie_info, err_severity, regs_dump from hisi_common_section_v2$conf{opt}{since} order by id, module_id, err_severity";
+            $query_handle = $dbh->prepare($query);
+            $query_handle->execute();
+            $query_handle->bind_columns(\($id, $timestamp, $version, $soc_id, $socket_id, $totem_id, $nimbus_id, $sub_system_id, $module_id, $sub_module_id, $core_id, $port_id, $err_type, $pcie_info, $err_severity, $regs));
+            $out = "";
+            while($query_handle->fetch()) {
+                if ($module eq 0 || ($module_id && uc($module) eq uc($module_id))) {
+                    $out .= "$id. $timestamp Error Info: ";
+                    $out .= "version=$version, ";
+                    $out .= "soc_id=$soc_id, " if ($soc_id);
+                    $out .= "socket_id=$socket_id, " if ($socket_id);
+                    $out .= "totem_id=$totem_id, " if ($totem_id);
+                    $out .= "nimbus_id=$nimbus_id, " if ($nimbus_id);
+                    $out .= "sub_system_id=$sub_system_id, " if ($sub_system_id);
+                    $out .= "module_id=$module_id, " if ($module_id);
+                    $out .= "sub_module_id=$sub_module_id, " if ($sub_module_id);
+                    $out .= "core_id=$core_id, " if ($core_id);
+                    $out .= "port_id=$port_id, " if ($port_id);
+                    $out .= "err_type=$err_type, " if ($err_type);
+                    $out .= "pcie_info=$pcie_info, " if ($pcie_info);
+                    $out .= "err_severity=$err_severity, " if ($err_severity);
+                    $out .= "Error Registers: $regs" if ($regs);
+                    $out .= "\n\n";
+                    $found_module = 1;
+	        }
+            }
+            if ($out ne "") {
+                print "HiSilicon KunPeng9xx common error events:\n$out\n";
+            }
+            $query_handle->finish;
+        } catch {
+            if ($DBI::errstr =~ "no such table") {
+                print "No HiSilicon KunPeng9xx common errors\n\n";
+            }  else {
+                print "Warning: $DBI::errstr when querying HiSilicon KunPeng9xx common errors\n\n";
+            }
+        };
     }
 
     if ($platform_id && !($found_platform)) {


### PR DESCRIPTION
1. rasdaemon: Fix return value type issue and some clean-up.
2. rasdaemon: ras-mc-ctl: Add handling of run-time errors reported when querying HiSilicon KunPeng9xx OEM errors.