### PR TITLE
rasdaemon: Fix return value type issue, some clean-ups and add support for creating vendor tables at startup

### DIFF
--- a/non-standard-hisi_hip08.c
+++ b/non-standard-hisi_hip08.c
@@ -654,6 +654,20 @@ static void decode_oem_type1_err_regs(struct ras_ns_ev_decoder *ev_decoder,
 	step_vendor_data_tab(ev_decoder, "hip08_oem_type1_event_tab");
 }
 
+static int add_hip08_oem_type1_table(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder)
+{
+#ifdef HAVE_SQLITE3
+	if (ras->record_events && !ev_decoder->stmt_dec_record) {
+		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
+					    &hip08_oem_type1_event_tab) != SQLITE_OK) {
+			log(TERM, LOG_WARNING, "Failed to create sql hip08_oem_type1_event_tab\n");
+			return -1;
+		}
+	}
+#endif
+	return 0;
+}
+
 /* error data decoding functions */
 static int decode_hip08_oem_type1_error(struct ras_events *ras,
 					struct ras_ns_ev_decoder *ev_decoder,
@@ -669,17 +683,6 @@ static int decode_hip08_oem_type1_error(struct ras_events *ras,
 		return -1;
 	}
 
-#ifdef HAVE_SQLITE3
-	if (ras->record_events && !ev_decoder->stmt_dec_record) {
-		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
-					    &hip08_oem_type1_event_tab)
-			!= SQLITE_OK) {
-			trace_seq_printf(s,
-					"create sql hip08_oem_type1_event_tab fail\n");
-			return -1;
-		}
-	}
-#endif
 	record_vendor_data(ev_decoder, HISI_OEM_DATA_TYPE_TEXT,
 			   HIP08_OEM_TYPE1_FIELD_TIMESTAMP,
 			   0, event->timestamp);
@@ -827,6 +830,20 @@ static void decode_oem_type2_err_regs(struct ras_ns_ev_decoder *ev_decoder,
 	step_vendor_data_tab(ev_decoder, "hip08_oem_type2_event_tab");
 }
 
+static int add_hip08_oem_type2_table(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder)
+{
+#ifdef HAVE_SQLITE3
+	if (ras->record_events && !ev_decoder->stmt_dec_record) {
+		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
+					    &hip08_oem_type2_event_tab) != SQLITE_OK) {
+			log(TERM, LOG_WARNING, "Failed to create sql hip08_oem_type2_event_tab\n");
+			return -1;
+		}
+	}
+#endif
+	return 0;
+}
+
 static int decode_hip08_oem_type2_error(struct ras_events *ras,
 					struct ras_ns_ev_decoder *ev_decoder,
 					struct trace_seq *s,
@@ -841,16 +858,6 @@ static int decode_hip08_oem_type2_error(struct ras_events *ras,
 		return -1;
 	}
 
-#ifdef HAVE_SQLITE3
-	if (ras->record_events && !ev_decoder->stmt_dec_record) {
-		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
-			&hip08_oem_type2_event_tab) != SQLITE_OK) {
-			trace_seq_printf(s,
-				"create sql hip08_oem_type2_event_tab fail\n");
-			return -1;
-		}
-	}
-#endif
 	record_vendor_data(ev_decoder, HISI_OEM_DATA_TYPE_TEXT,
 			   HIP08_OEM_TYPE2_FIELD_TIMESTAMP,
 			   0, event->timestamp);
@@ -977,6 +984,20 @@ static void decode_pcie_local_err_regs(struct ras_ns_ev_decoder *ev_decoder,
 	step_vendor_data_tab(ev_decoder, "hip08_pcie_local_event_tab");
 }
 
+static int add_hip08_pcie_local_table(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder)
+{
+#ifdef HAVE_SQLITE3
+	if (ras->record_events && !ev_decoder->stmt_dec_record) {
+		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
+					    &hip08_pcie_local_event_tab) != SQLITE_OK) {
+			log(TERM, LOG_WARNING, "Failed to create sql hip08_pcie_local_event_tab\n");
+			return -1;
+		}
+	}
+#endif
+	return 0;
+}
+
 static int decode_hip08_pcie_local_error(struct ras_events *ras,
 					 struct ras_ns_ev_decoder *ev_decoder,
 					 struct trace_seq *s,
@@ -991,16 +1012,6 @@ static int decode_hip08_pcie_local_error(struct ras_events *ras,
 		return -1;
 	}
 
-#ifdef HAVE_SQLITE3
-	if (ras->record_events && !ev_decoder->stmt_dec_record) {
-		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
-				&hip08_pcie_local_event_tab) != SQLITE_OK) {
-			trace_seq_printf(s,
-				"create sql hip08_pcie_local_event_tab fail\n");
-			return -1;
-		}
-	}
-#endif
 	record_vendor_data(ev_decoder, HISI_OEM_DATA_TYPE_TEXT,
 			   HIP08_PCIE_LOCAL_FIELD_TIMESTAMP,
 			   0, event->timestamp);
@@ -1015,14 +1026,17 @@ static int decode_hip08_pcie_local_error(struct ras_events *ras,
 static struct ras_ns_ev_decoder hip08_ns_ev_decoder[] = {
 	{
 		.sec_type = "1f8161e1-55d6-41e6-bd10-7afd1dc5f7c5",
+		.add_table = add_hip08_oem_type1_table,
 		.decode = decode_hip08_oem_type1_error,
 	},
 	{
 		.sec_type = "45534ea6-ce23-4115-8535-e07ab3aef91d",
+		.add_table = add_hip08_oem_type2_table,
 		.decode = decode_hip08_oem_type2_error,
 	},
 	{
 		.sec_type = "b2889fc9-e7d7-4f9d-a867-af42e98be772",
+		.add_table = add_hip08_pcie_local_table,
 		.decode = decode_hip08_pcie_local_error,
 	},
 };

--- a/non-standard-hisi_hip08.c
+++ b/non-standard-hisi_hip08.c
@@ -1029,7 +1029,7 @@ static struct ras_ns_ev_decoder hip08_ns_ev_decoder[] = {
 
 static void __attribute__((constructor)) hip08_init(void)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(hip08_ns_ev_decoder); i++)
 		register_ns_ev_decoder(&hip08_ns_ev_decoder[i]);

--- a/non-standard-hisilicon.c
+++ b/non-standard-hisilicon.c
@@ -366,13 +366,13 @@ static int decode_hisi_common_section(struct ras_events *ras,
 	trace_seq_printf(s, "%s\n", hevent.error_msg);
 
 	if (err->val_bits & BIT(HISI_COMMON_VALID_REG_ARRAY_SIZE) && err->reg_array_size > 0) {
-		int i;
+		unsigned int i;
 
 		trace_seq_printf(s, "Register Dump:\n");
 		for (i = 0; i < err->reg_array_size / sizeof(uint32_t); i++) {
-			trace_seq_printf(s, "reg%02d=0x%08x\n", i,
+			trace_seq_printf(s, "reg%02u=0x%08x\n", i,
 					 err->reg_array[i]);
-			HISI_SNPRINTF(hevent.reg_msg, "reg%02d=0x%08x",
+			HISI_SNPRINTF(hevent.reg_msg, "reg%02u=0x%08x",
 				      i, err->reg_array[i]);
 		}
 	}
@@ -398,7 +398,7 @@ static struct ras_ns_ev_decoder hisi_section_ns_ev_decoder[]  = {
 
 static void __attribute__((constructor)) hisi_ns_init(void)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(hisi_section_ns_ev_decoder); i++)
 		register_ns_ev_decoder(&hisi_section_ns_ev_decoder[i]);

--- a/ras-diskerror-handler.c
+++ b/ras-diskerror-handler.c
@@ -52,7 +52,7 @@ static const struct {
 
 static const char *get_blk_error(int err)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(blk_errors); i++)
 		if (blk_errors[i].error == err)

--- a/ras-events.c
+++ b/ras-events.c
@@ -474,6 +474,10 @@ static int read_ras_event_all_cpus(struct pthread_data *pdata,
 	if (pdata[0].ras->record_events) {
 		if (ras_mc_event_opendb(pdata[0].cpu, pdata[0].ras))
 			goto error;
+#ifdef HAVE_NON_STANDARD
+		if (ras_ns_add_vendor_tables(pdata[0].ras))
+			log(TERM, LOG_ERR, "Can't add vendor table\n");
+#endif
 	}
 
 	do {
@@ -558,8 +562,12 @@ static int read_ras_event_all_cpus(struct pthread_data *pdata,
 	    "Old kernel detected. Stop listening and fall back to pthread way.\n");
 
 cleanup:
-	if (pdata[0].ras->record_events)
+	if (pdata[0].ras->record_events) {
+#ifdef HAVE_NON_STANDARD
+		ras_ns_finalize_vendor_tables();
+#endif
 		ras_mc_event_closedb(pdata[0].cpu, pdata[0].ras);
+	}
 
 error:
 	kbuffer_free(kbuf);
@@ -656,6 +664,10 @@ static void *handle_ras_events_cpu(void *priv)
 			free(page);
 			return 0;
 		}
+#ifdef HAVE_NON_STANDARD
+		if (ras_ns_add_vendor_tables(pdata->ras))
+			log(TERM, LOG_ERR, "Can't add vendor table\n");
+#endif
 		pthread_mutex_unlock(&pdata->ras->db_lock);
 	}
 
@@ -663,6 +675,9 @@ static void *handle_ras_events_cpu(void *priv)
 
 	if (pdata->ras->record_events) {
 		pthread_mutex_lock(&pdata->ras->db_lock);
+#ifdef HAVE_NON_STANDARD
+		ras_ns_finalize_vendor_tables();
+#endif
 		ras_mc_event_closedb(pdata->cpu, pdata->ras);
 		pthread_mutex_unlock(&pdata->ras->db_lock);
 	}

--- a/ras-memory-failure-handler.c
+++ b/ras-memory-failure-handler.c
@@ -15,11 +15,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <traceevent/kbuffer.h>
-#include "ras-memory-failure-handler.h"
 #include "ras-record.h"
 #include "ras-logger.h"
 #include "ras-report.h"
+#include "ras-memory-failure-handler.h"
 
 /* Memory failure - various types of pages */
 enum mf_action_page_type {
@@ -99,7 +98,7 @@ static const struct {
 
 static const char *get_page_type(int page_type)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(mf_page_type); i++)
 		if (mf_page_type[i].type == page_type)
@@ -110,7 +109,7 @@ static const char *get_page_type(int page_type)
 
 static const char *get_action_result(int result)
 {
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(mf_action_result); i++)
 		if (mf_action_result[i].result == result)

--- a/ras-non-standard-handler.h
+++ b/ras-non-standard-handler.h
@@ -20,6 +20,7 @@
 struct ras_ns_ev_decoder {
 	struct ras_ns_ev_decoder *next;
 	const char *sec_type;
+	int (*add_table)(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder);
 	int (*decode)(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder,
 		      struct trace_seq *s, struct ras_non_standard_event *event);
 #ifdef HAVE_SQLITE3
@@ -36,6 +37,8 @@ void print_le_hex(struct trace_seq *s, const uint8_t *buf, int index);
 
 #ifdef HAVE_NON_STANDARD
 int register_ns_ev_decoder(struct ras_ns_ev_decoder *ns_ev_decoder);
+int ras_ns_add_vendor_tables(struct ras_events *ras);
+void ras_ns_finalize_vendor_tables(void);
 #else
 static inline int register_ns_ev_decoder(struct ras_ns_ev_decoder *ns_ev_decoder) { return 0; };
 #endif


### PR DESCRIPTION
1. Fix return value type issue and some clean-up.
2. Fix issue of signed and unsigned integer comparison.
3. Add support for creating the vendor error tables at startup.
4. Make changes in the HiSilicon error handling code for the same.
