### PR TITLE
fix the issue of incorrect device id in diskerrors.

### DIFF
--- a/ras-diskerror-handler.c
+++ b/ras-diskerror-handler.c
@@ -31,6 +31,17 @@
 #include "ras-report.h"
 
 
+#define KERNEL_DEVICE_ID_BITS 20
+#define KERNEL_DEVICE_ID_MASK ((1U << KERNEL_DEVICE_ID_BITS) - 1)
+static unsigned int major(dev_t devid)
+{
+	return (unsigned int)(devid >> KERNEL_DEVICE_ID_BITS);
+}
+static unsigned int minor(dev_t devid)
+{
+	return (unsigned int)(devid & KERNEL_DEVICE_ID_MASK);
+}
+
 static const struct {
 	int             error;
 	const char      *name;


### PR DESCRIPTION
The device ID of a block event is organized in kernel space, and the device ID obtained by user space processes is also organized in kernel space. Therefore, it needs to be parsed in kernel mode.
Kernel Space Definition：
```
TRACE_EVENT(block_rq_complete,

	TP_PROTO(struct request *rq, int error, unsigned int nr_bytes),

	TP_ARGS(rq, error, nr_bytes),

	TP_STRUCT__entry(
		__field(  dev_t,	dev			)
		__field(  sector_t,	sector			)
		__field(  unsigned int,	nr_sector		)
		__field(  int,		error			)
		__array(  char,		rwbs,	RWBS_LEN	)
		__dynamic_array( char,	cmd,	1		)
	),

	TP_fast_assign(
		__entry->dev	   = rq->rq_disk ? disk_devt(rq->rq_disk) : 0;
		__entry->sector    = blk_rq_pos(rq);
		__entry->nr_sector = nr_bytes >> 9;
		__entry->error     = error;

		blk_fill_rwbs(__entry->rwbs, rq->cmd_flags, nr_bytes);
		__get_str(cmd)[0] = '\0';
	),

	TP_printk("%d,%d %s (%s) %llu + %u [%d]",
		  MAJOR(__entry->dev), MINOR(__entry->dev),
		  __entry->rwbs, __get_str(cmd),
		  (unsigned long long)__entry->sector,
		  __entry->nr_sector, __entry->error)
);
```