### PR TITLE
Check CPUs online, not configured.

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -345,7 +345,7 @@ static void parse_ras_data(struct pthread_data *pdata, struct kbuffer *kbuf,
 
 static int get_num_cpus(struct ras_events *ras)
 {
-	return sysconf(_SC_NPROCESSORS_CONF);
+	return sysconf(_SC_NPROCESSORS_ONLN);
 #if 0
 	char fname[MAX_PATH + 1];
 	int num_cpus = 0;


### PR DESCRIPTION
When the number of CPUs detected is greater than the number of CPUs in the system, rasdaemon will crash when it receives some events.

Looking deeper, we also fail to use the poll method for similar reasons in this case.

All of this can be prevented by checking to see how many CPUs are currently online (sysconf(_SC_NPROCESSORS_ONLN)) instead of how many CPUs the current kernel was configured to support
(sysconf(_SC_NPROCESSORS_CONF)).

For the kernel side of the discussion, see https://lore.kernel.org/lkml/CAM6Wdxft33zLeeXHhmNX5jyJtfGTLiwkQSApc=10fqf+rQh9DA@mail.gmail.com/T/