### PR TITLE
Add label for mainboard: ASUSTeK COMPUTER INC. Model: Z9PH-D16 Series

### DIFF
--- a/labels/asus
+++ b/labels/asus
@@ -22,3 +22,24 @@ Vendor: ASUSTeK COMPUTER INC.
   Model: TUF GAMING B450-PLUS II
     DIMM_A1:  0.0.1, 0.1.1;    DIMM_A2:   0.2.1, 0.3.1;
     DIMM_B1:  0.0.0, 0.1.0;    DIMM_B2:   0.2.0, 0.3.0;
+
+  Model: Z9PH-D16 Series
+    CPU1_DIMM_A1: 0.0.0
+    CPU1_DIMM_A2: 0.0.1
+    CPU1_DIMM_B1: 0.1.0
+    CPU1_DIMM_B2: 0.1.1
+
+    CPU1_DIMM_C1: 0.2.0
+    CPU1_DIMM_C2: 0.2.1
+    CPU1_DIMM_D1: 0.3.0
+    CPU1_DIMM_D2: 0.3.1
+
+    CPU2_DIMM_E1: 1.0.0
+    CPU2_DIMM_E2: 1.0.1
+    CPU2_DIMM_F1: 1.1.0
+    CPU2_DIMM_F2: 1.1.1
+
+    CPU2_DIMM_G1: 1.2.0
+    CPU2_DIMM_G2: 1.2.1
+    CPU2_DIMM_H1: 1.3.0
+    CPU2_DIMM_H2: 1.3.1


### PR DESCRIPTION
https://www.intel.com/content/dam/support/us/en/documents/server-products/server-boards/Intel_Server_Board_S2600WT_TPS.pdf

Mainbord doc (Page 39):
https://dlcdnets.asus.com/pub/ASUS/mb/Socket2011/Z9PH-D16/Manual/e7171_Z9PH-D16_WEBSITE.pdf?model=z9ph-d16