### PR TITLE
add ':' before error output

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1469,7 +1469,7 @@ sub errors
             $out .= "\n";
         }
         if ($out ne "") {
-            print "Disk errors\n$out\n";
+            print "Disk errors:\n$out\n";
         } else {
             print "No disk errors.\n\n";
         }


### PR DESCRIPTION
All prints except disk are preceded by a colon