### PR TITLE
rasdaemon: Add Emerald Rapids support

### DIFF
--- a/mce-intel-i10nm.c
+++ b/mce-intel-i10nm.c
@@ -380,6 +380,7 @@ void i10nm_decode_model(enum cputype cputype, struct ras_events *ras,
 		banktype = tremont[e->bank];
 		break;
 	case CPU_SAPPHIRERAPIDS:
+	case CPU_EMERALDRAPIDS:
 		banktype = sapphire[e->bank];
 		break;
 	default:

--- a/mce-intel.c
+++ b/mce-intel.c
@@ -415,6 +415,7 @@ int parse_intel_event(struct ras_events *ras, struct mce_event *e)
 	case CPU_ICELAKE_DE:
 	case CPU_TREMONT_D:
 	case CPU_SAPPHIRERAPIDS:
+	case CPU_EMERALDRAPIDS:
 		i10nm_decode_model(mce->cputype, ras, e);
 	default:
 		break;

--- a/ras-mce-handler.c
+++ b/ras-mce-handler.c
@@ -61,6 +61,7 @@ static char *cputype_name[] = {
 	[CPU_ICELAKE_DE] = "Icelake server D Family",
 	[CPU_TREMONT_D] = "Tremont microserver",
 	[CPU_SAPPHIRERAPIDS] = "Sapphirerapids server",
+	[CPU_EMERALDRAPIDS] = "Emeraldrapids server",
 };
 
 static enum cputype select_intel_cputype(struct ras_events *ras)
@@ -120,6 +121,8 @@ static enum cputype select_intel_cputype(struct ras_events *ras)
                         return CPU_TREMONT_D;
 		else if (mce->model == 0x8f)
                         return CPU_SAPPHIRERAPIDS;
+		else if (mce->model == 0xcf)
+			return CPU_EMERALDRAPIDS;
 
 		if (mce->model > 0x1a) {
 			log(ALL, LOG_INFO,

--- a/ras-mce-handler.h
+++ b/ras-mce-handler.h
@@ -53,6 +53,7 @@ enum cputype {
 	CPU_ICELAKE_DE,
 	CPU_TREMONT_D,
 	CPU_SAPPHIRERAPIDS,
+	CPU_EMERALDRAPIDS,
 };
 
 struct mce_event {


### PR DESCRIPTION
The decoding for Emerald Rapids is the same as Sapphire Rapids