### PR TITLE
rasdaemon: Add support for vendor-specific machine check error information

### DIFF
--- a/mce-amd-smca.c
+++ b/mce-amd-smca.c
@@ -965,6 +965,18 @@ void decode_smca_error(struct mce_event *e, struct mce_priv *m)
 			     channel, csrow);
 	}
 
+
+	if (e->vdata_len) {
+		uint64_t smca_config = e->vdata[2];
+
+		/*
+		 * BIT 9 of the CONFIG register of a few SMCA Bank types indicates
+		 * presence of FRU Text in SYND 1 / 2 registers
+		 */
+		if (smca_config & BIT(9))
+			memcpy(e->frutext, e->vdata, 16);
+	}
+
 }
 
 int parse_amd_smca_event(struct ras_events *ras, struct mce_event *e)

--- a/ras-mce-handler.h
+++ b/ras-mce-handler.h
@@ -75,8 +75,11 @@ struct mce_event {
 	uint8_t		cpuvendor;
 	uint64_t        synd;   /* MCA_SYND MSR: only valid on SMCA systems */
 	uint64_t        ipid;   /* MCA_IPID MSR: only valid on SMCA systems */
+	int32_t		vdata_len;
+	const uint64_t	*vdata;
 
 	/* Parsed data */
+	char		frutext[17];
 	char		timestamp[64];
 	char		bank_name[64];
 	char		error_msg[4096];


### PR DESCRIPTION
This patch adds support for vendor-specific error information that may be provided through tracepoints by the kernel.

Patches adding the necessary, corresponding support in the kernel have been submitted upstream too.

https://lore.kernel.org/linux-edac/20231118193248.1296798-1-yazen.ghannam@amd.com/T/#t

(Patches 17 - 20)