### PR TITLE
Add dynamic switch of ras events support.

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -158,6 +158,12 @@ static int __toggle_ras_mc_event(struct ras_events *ras,
 {
 	int fd, rc;
 	char fname[MAX_PATH + 1];
+	extern char* choices_disable;
+
+	snprintf(ras_event_name, sizeof(ras_event_name), "%s:%s",
+			group, event);
+
+	enable = (choices_disable != NULL && strlen(choices_disable) != 0 && strstr(choices_disable, ras_event_name)) ? 0 : 1;
 
 	snprintf(fname, sizeof(fname), "%s%s:%s\n",
 		 enable ? "" : "!",
@@ -772,6 +778,8 @@ static int add_event_handler(struct ras_events *ras, struct tep_handle *pevent,
 	int fd, size, rc;
 	char *page, fname[MAX_PATH + 1];
 	struct tep_event_filter * filter = NULL;
+	char ras_event_name[MAX_PATH + 1];
+	extern char* choices_disable;
 
 	snprintf(fname, sizeof(fname), "events/%s/%s/format", group, event);
 
@@ -838,6 +846,15 @@ static int add_event_handler(struct ras_events *ras, struct tep_handle *pevent,
 	}
 
 	ras->filters[id] = filter;
+
+	snprintf(ras_event_name, sizeof(ras_event_name), "%s:%s",
+			group, event);
+	if (choices_disable != NULL && strlen(choices_disable) != 0
+		&& strstr(choices_disable, ras_event_name)) {
+		log(ALL, LOG_INFO, "Disabled %s:%s tracing from config\n",
+                    group, event);
+		return -EINVAL;
+	}
 
 	/* Enable RAS events */
 	rc = __toggle_ras_mc_event(ras, group, event, 1);
@@ -906,7 +923,7 @@ int handle_ras_events(int record_events)
 			       ras_mc_event_handler, NULL, MC_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "mc_event");
 
@@ -915,7 +932,7 @@ int handle_ras_events(int record_events)
 			       ras_aer_event_handler, NULL, AER_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "aer_event");
 #endif
@@ -925,7 +942,7 @@ int handle_ras_events(int record_events)
 			       ras_non_standard_event_handler, NULL, NON_STANDARD_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "non_standard_event");
 #endif
@@ -935,7 +952,7 @@ int handle_ras_events(int record_events)
 			       ras_arm_event_handler, NULL, ARM_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "arm_event");
 #endif
@@ -969,7 +986,7 @@ int handle_ras_events(int record_events)
 		/* tell kernel we are listening, so don't printk to console */
 		(void)open("/sys/kernel/debug/ras/daemon_active", 0);
 		num_events++;
-	} else
+	} else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "extlog_mem_event");
 #endif
@@ -986,7 +1003,7 @@ int handle_ras_events(int record_events)
 			       ras_devlink_event_handler, filter_str, DEVLINK_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "devlink", "devlink_health_report");
 #endif
@@ -998,7 +1015,7 @@ int handle_ras_events(int record_events)
 				NULL, DISKERROR_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "block", "block_rq_error");
 #else
@@ -1009,7 +1026,7 @@ int handle_ras_events(int record_events)
 					NULL, DISKERROR_EVENT);
 		if (!rc)
 			num_events++;
-		else
+		else if (rc != -EINVAL)
 			log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 			    "block", "block_rq_complete");
 	}
@@ -1021,7 +1038,7 @@ int handle_ras_events(int record_events)
 			       ras_memory_failure_event_handler, NULL, MF_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "ras", "memory_failure_event");
 #endif
@@ -1031,7 +1048,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_poison_event_handler, NULL, CXL_POISON_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_poison");
 
@@ -1039,7 +1056,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_aer_ue_event_handler, NULL, CXL_AER_UE_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_aer_uncorrectable_error");
 
@@ -1047,7 +1064,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_aer_ce_event_handler, NULL, CXL_AER_CE_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_aer_correctable_error");
 
@@ -1055,7 +1072,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_overflow_event_handler, NULL, CXL_OVERFLOW_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_overflow");
 
@@ -1063,7 +1080,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_generic_event_handler, NULL, CXL_GENERIC_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_generic_event");
 
@@ -1071,7 +1088,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_general_media_event_handler, NULL, CXL_GENERAL_MEDIA_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_general_media");
 
@@ -1079,7 +1096,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_dram_event_handler, NULL, CXL_DRAM_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "cxl_dram");
 
@@ -1087,7 +1104,7 @@ int handle_ras_events(int record_events)
 			       ras_cxl_memory_module_event_handler, NULL, CXL_MEMORY_MODULE_EVENT);
 	if (!rc)
 		num_events++;
-	else
+	else if (rc != -EINVAL)
 		log(ALL, LOG_ERR, "Can't get traces from %s:%s\n",
 		    "cxl", "memory_module");
 #endif

--- a/rasdaemon.c
+++ b/rasdaemon.c
@@ -33,6 +33,8 @@
 #define TOOL_NAME "rasdaemon"
 #define TOOL_DESCRIPTION "RAS daemon to log the RAS events."
 #define ARGS_DOC "<options>"
+#define DISABLE "DISABLE"
+char *choices_disable = NULL;
 
 const char *argp_program_version = TOOL_NAME " " VERSION;
 const char *argp_program_bug_address = "Mauro Carvalho Chehab <mchehab@kernel.org>";
@@ -127,6 +129,7 @@ int main(int argc, char *argv[])
 {
 	struct arguments args;
 	int idx = -1;
+	choices_disable = getenv(DISABLE);
 
 #ifdef HAVE_MCE
 	const struct argp_option offline_options[] = {


### PR DESCRIPTION
Rasdaemon does not support a way to disable some events by config. If user want to disable specified event(eg:block_rq_complete), he should recompile rasdaemon, which is not so convenient.

This patch add dynamic switch of ras event support.You can add events you want to disabled in /etc/sysconfig/rasdaemon.For example, `DISABLE="ras:mc_event,block:block_rq_complete"`.Then restart rasdaemon, these two events will be disabled without recompilation.