### PR TITLE
Add dynamic switch of ras events support.

### DIFF
--- a/rasdaemon.c
+++ b/rasdaemon.c
@@ -33,6 +33,8 @@
 #define TOOL_NAME "rasdaemon"
 #define TOOL_DESCRIPTION "RAS daemon to log the RAS events."
 #define ARGS_DOC "<options>"
+#define DISABLE "DISABLE"
+char *choices_disable = NULL;
 
 const char *argp_program_version = TOOL_NAME " " VERSION;
 const char *argp_program_bug_address = "Mauro Carvalho Chehab <mchehab@kernel.org>";
@@ -127,6 +129,7 @@ int main(int argc, char *argv[])
 {
 	struct arguments args;
 	int idx = -1;
+	choices_disable = getenv(DISABLE);
 
 #ifdef HAVE_MCE
 	const struct argp_option offline_options[] = {


### PR DESCRIPTION
Rasdaemon does not support a way to disable some events by config. If user want to disable specified event(eg:block_rq_complete), he should recompile rasdaemon, which is not so convenient.

This patch add dynamic switch of ras event support.You can add events you want to disabled in /etc/sysconfig/rasdaemon.For example, `DISABLE="ras:mc_event,block:block_rq_complete"`.Then restart rasdaemon, these two events will be disabled without recompilation.