### PR TITLE
Fix ras-mc-ctl script breaks trying to query data from nonexistent tables.

### DIFF
--- a/non-standard-yitian.c
+++ b/non-standard-yitian.c
@@ -164,16 +164,6 @@ void decode_yitian_ddr_payload_err_regs(struct ras_ns_ev_decoder *ev_decoder,
 	const char *subtype_str  = oem_subtype_name(yitian_payload_error_type,
 					header->type, header->subtype);
 
-#ifdef HAVE_SQLITE3
-	if (ras->record_events && !ev_decoder->stmt_dec_record) {
-		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
-				&yitian_ddr_payload_section_tab) != SQLITE_OK) {
-			trace_seq_printf(s, "create sql fail\n");
-			return;
-		}
-	}
-#endif
-
 	now = time(NULL);
 	tm = localtime(&now);
 	if (tm)
@@ -217,6 +207,22 @@ void decode_yitian_ddr_payload_err_regs(struct ras_ns_ev_decoder *ev_decoder,
 
 }
 
+static int add_yitian_common_table(struct ras_events *ras,
+				 struct ras_ns_ev_decoder *ev_decoder)
+{
+#ifdef HAVE_SQLITE3
+	if (ras->record_events && !ev_decoder->stmt_dec_record) {
+		if (ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
+				&yitian_ddr_payload_section_tab) != SQLITE_OK) {
+			log(TERM, LOG_WARNING,
+				"Failed to create sql yitian_ddr_payload_section_tab\n");
+			return -1;
+		}
+	}
+#endif
+	return 0;
+}
+
 /* error data decoding functions */
 static int decode_yitian710_ns_error(struct ras_events *ras,
 				     struct ras_ns_ev_decoder *ev_decoder,
@@ -239,6 +245,7 @@ static int decode_yitian710_ns_error(struct ras_events *ras,
 struct ras_ns_ev_decoder yitian_ns_oem_decoder[] = {
 	{
 		.sec_type = "a6980811-16ea-4e4d-b936-fb00a23ff29c",
+		.add_table = add_yitian_common_table,
 		.decode = decode_yitian710_ns_error,
 	},
 };


### PR DESCRIPTION
When rasdaemon is running without non-standard error,those tables are not created in the database file. Then ras-mc-ctl script breaks trying to query data from non-existent tables.Add support for creating vendor tables at startup.