### PR TITLE
rasdaemon: Do't process Ampere specific error in the public code

### DIFF
--- a/ras-arm-handler.c
+++ b/ras-arm-handler.c
@@ -158,7 +158,6 @@ int ras_arm_event_handler(struct trace_seq *s,
 	time_t now;
 	struct tm *tm;
 	struct ras_arm_event ev;
-	int len = 0;
 
 	memset(&ev, 0, sizeof(ev));
 
@@ -207,6 +206,9 @@ int ras_arm_event_handler(struct trace_seq *s,
 	ev.psci_state = val;
 	trace_seq_printf(s, "\n psci_state: %d", ev.psci_state);
 
+#ifdef HAVE_AMP_NS_DECODE
+	int len = 0;
+
 	if (tep_get_field_val(s, event, "pei_len", record, &val, 1) < 0)
 		return -1;
 	ev.pei_len = val;
@@ -239,12 +241,9 @@ int ras_arm_event_handler(struct trace_seq *s,
 	if (!ev.vsei_error)
 		return -1;
 
-#ifdef HAVE_AMP_NS_DECODE
 	//decode ampere specific error
 	decode_amp_payload0_err_regs(NULL, s,
 				(struct amp_payload0_type_sec *)ev.vsei_error);
-#else
-	display_raw_data(s, ev.vsei_error, ev.oem_len);
 #endif
 
 #ifdef HAVE_CPU_FAULT_ISOLATION

--- a/ras-record.c
+++ b/ras-record.c
@@ -212,9 +212,11 @@ static const struct db_fields arm_event_fields[] = {
 		{ .name="mpidr",		.type="INTEGER" },
 		{ .name="running_state",	.type="INTEGER" },
 		{ .name="psci_state",		.type="INTEGER" },
+#ifdef HAVE_AMP_NS_DECODE
 		{ .name="err_info",		.type="BLOB"	},
 		{ .name="context_info",		.type="BLOB"	},
 		{ .name="vendor_info",		.type="BLOB"	},
+#endif
 };
 
 static const struct db_table_descriptor arm_event_tab = {
@@ -238,12 +240,14 @@ int ras_store_arm_record(struct ras_events *ras, struct ras_arm_event *ev)
 	sqlite3_bind_int64  (priv->stmt_arm_record,  4,  ev->mpidr);
 	sqlite3_bind_int  (priv->stmt_arm_record,  5,  ev->running_state);
 	sqlite3_bind_int  (priv->stmt_arm_record,  6,  ev->psci_state);
+#ifdef HAVE_AMP_NS_DECODE
 	sqlite3_bind_blob (priv->stmt_arm_record,  7,
 			    ev->pei_error, ev->pei_len, NULL);
 	sqlite3_bind_blob (priv->stmt_arm_record,  8,
 			    ev->ctx_error, ev->ctx_len, NULL);
 	sqlite3_bind_blob (priv->stmt_arm_record,  9,
 			    ev->vsei_error, ev->oem_len, NULL);
+#endif
 
 	rc = sqlite3_step(priv->stmt_arm_record);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)

--- a/ras-record.h
+++ b/ras-record.h
@@ -80,12 +80,14 @@ struct ras_arm_event {
 	int64_t midr;
 	int32_t running_state;
 	int32_t psci_state;
+#ifdef HAVE_AMP_NS_DECODE
 	const uint8_t *pei_error;
 	uint32_t pei_len;
 	const uint8_t *ctx_error;
 	uint32_t ctx_len;
 	const uint8_t *vsei_error;
 	uint32_t oem_len;
+#endif
 };
 
 struct devlink_event {


### PR DESCRIPTION
Ampere specific error info and error handler need to included in HAVE_AMP_NS_DECODE macro.