### PR TITLE
rasdaemon: add mc_event trigger

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ all-local: $(SYSTEMD_SERVICES)
 
 sbin_PROGRAMS = rasdaemon
 rasdaemon_SOURCES = rasdaemon.c ras-events.c ras-mc-handler.c \
-		    bitfield.c
+		    bitfield.c trigger.c
 if WITH_SQLITE3
    rasdaemon_SOURCES += ras-record.c
 endif
@@ -93,7 +93,7 @@ include_HEADERS = config.h  ras-events.h  ras-logger.h  ras-mc-handler.h \
 		  ras-devlink-handler.h ras-diskerror-handler.h rbtree.h ras-page-isolation.h \
 		  non-standard-hisilicon.h non-standard-ampere.h ras-memory-failure-handler.h \
 		  ras-cxl-handler.h ras-cpu-isolation.h queue.h non-standard-yitian.h \
-		  non-standard-jaguarmicro.h
+		  non-standard-jaguarmicro.h trigger.h
 
 # This rule can't be called with more than one Makefile job (like make -j8)
 # I can't figure out a way to fix that
@@ -120,6 +120,6 @@ upload:
 # custom target
 install-data-local:
 	$(install_sh) -d "$(DESTDIR)@sysconfdir@/ras/dimm_labels.d"
-if WITH_MEMORY_CE_PFA
+	$(install_sh) -d "$(DESTDIR)@sysconfdir@/ras/triggers"
 	$(install_sh) @abs_srcdir@/misc/rasdaemon.env "$(DESTDIR)@SYSCONFDEFDIR@/rasdaemon"
-endif
+	$(install_sh) @abs_srcdir@/contrib/mc_event_trigger "$(DESTDIR)@sysconfdir@/ras/triggers/mc_event_trigger"

--- a/contrib/mc_event_trigger
+++ b/contrib/mc_event_trigger
@@ -1,0 +1,24 @@
+#!/bin/sh
+#  This shell script can be executed by rasdaemon in daemon mode when a
+#  mc_event is occured, environment variables include all information
+#  reported by tracepoint.
+#
+# environment:
+# TIMESTAMP     Timestamp when error occurred
+# COUNT         Number of errors of the same type
+# TYPE          Error type from Corrected/Uncorrected
+# MESSAGE       Error message
+# LABEL         Label of the affected DIMM(s)
+# MC_INDEX      DIMM identifier from DMI/SMBIOS if available
+# TOP_LAYER     Top layer of the error
+# MIDDLE_LAYER  Middle layer of the error
+# LOWER_LAYER   Low layer of the error
+# ADDRESS       Error address
+# GRAIN         Minimum granularity for an error report, in bytes
+# SYNDROME      Syndrome of the error (or 0 if unknown or if the syndrome is not applicable)
+# DRIVER_DETAIL Other driver-specific detail about the error
+#
+
+[ -x ./mc_event_trigger.local ] && . ./mc_event_trigger.local
+
+exit 0

--- a/misc/rasdaemon.env
+++ b/misc/rasdaemon.env
@@ -44,3 +44,19 @@ CPU_ISOLATION_CYCLE="24h"
 
 # Prevent excessive isolation from causing an avalanche effect
 CPU_ISOLATION_LIMIT="10"
+
+# Event Trigger
+
+# Event trigger will be executed when the specified event occurs.
+#
+# Execute triggers path
+# For example: TRIGGER_DIR=/etc/ras/triggers
+TRIGGER_DIR=
+
+# Execute these triggers when the mc_event occured, the triggers will not
+# be executed if the trigger is not specified.
+# For example:
+#   MC_CE_TRIGGER=mc_event_trigger
+#   MC_UE_TRIGGER=mc_event_trigger
+MC_CE_TRIGGER=
+MC_UE_TRIGGER=

--- a/ras-events.c
+++ b/ras-events.c
@@ -45,6 +45,7 @@
 #include "ras-logger.h"
 #include "ras-page-isolation.h"
 #include "ras-cpu-isolation.h"
+#include "trigger.h"
 
 /*
  * Polling time, if read() doesn't block. Currently, trace_pipe_raw never
@@ -61,6 +62,10 @@
 #endif
 
 extern char *choices_disable;
+
+const static struct event_trigger event_triggers[] = {
+	{ "mc_event", &mc_event_trigger_setup },
+};
 
 static int get_debugfs_dir(char *tracing_dir, size_t len)
 {
@@ -275,6 +280,16 @@ int toggle_ras_mc_event(int enable)
 free_ras:
 	free(ras);
 	return rc;
+}
+
+static void setup_event_trigger(char *event)
+{
+	struct event_trigger trigger;
+	for (int i = 0; i < ARRAY_SIZE(event_triggers); i++) {
+		trigger = event_triggers[i];
+		if (!strcmp(event, trigger.name))
+			trigger.setup();
+	}
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
@@ -870,6 +885,8 @@ static int add_event_handler(struct ras_events *ras, struct tep_handle *pevent,
 
 		return EINVAL;
 	}
+
+	setup_event_trigger(event);
 
 	log(ALL, LOG_INFO, "Enabled event %s:%s\n", group, event);
 

--- a/ras-mc-handler.h
+++ b/ras-mc-handler.h
@@ -22,6 +22,8 @@
 #include "ras-events.h"
 #include <traceevent/event-parse.h>
 
+void mc_event_trigger_setup(void);
+
 int ras_mc_event_handler(struct trace_seq *s,
 			 struct tep_record *record,
 			 struct tep_event *event, void *context);

--- a/trigger.c
+++ b/trigger.c
@@ -1,0 +1,61 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include "ras-logger.h"
+#include "trigger.h"
+
+void run_trigger(const char *trigger, char *argv[], char **env, const char* reporter)
+{
+        pid_t child;
+        char *path;
+        int status;
+        char *trigger_dir = getenv("TRIGGER_DIR");
+
+
+        log(SYSLOG, LOG_INFO, "Running trigger `%s' (reporter: %s)\n", trigger, reporter);
+
+	if (asprintf(&path, "%s/%s", trigger_dir, trigger) < 0)
+		return;
+
+        child = fork();
+        if (child < 0) {
+                log(SYSLOG, LOG_ERR, "Cannot create process for trigger");
+                return;
+        }
+
+        if (child == 0) {
+                execve(path, argv, env);
+                _exit(127);
+        } else {
+                waitpid(child, &status, 0);
+                if (WIFEXITED(status) && WEXITSTATUS(status)) {
+                        log(SYSLOG, LOG_INFO, "Trigger %s exited with status %d",
+                                trigger, WEXITSTATUS(status));
+                } else if (WIFSIGNALED(status)) {
+                        log(SYSLOG, LOG_INFO, "Trigger %s killed by signal %d",
+                                trigger, WTERMSIG(status));
+                }
+        }
+}
+
+int trigger_check(char *s)
+{
+        char *name;
+        int rc;
+        char *trigger_dir = getenv("TRIGGER_DIR");
+
+        if (trigger_dir) {
+                if (asprintf(&name, "%s/%s", trigger_dir, s) < 0)
+                        return -1;
+        } else
+                name = s;
+
+        rc = access(name, R_OK|X_OK);
+
+        if (trigger_dir)
+                free(name);
+
+        return rc;
+}

--- a/trigger.h
+++ b/trigger.h
@@ -1,0 +1,13 @@
+#ifndef __TRIGGER_H__
+#define __TRIGGER_H__
+
+struct event_trigger {
+        const char *name;
+        void (*setup)(void);
+};
+
+int trigger_check(char *s);
+void run_trigger(const char *trigger, char *argv[], char **env, const char* reporter);
+
+
+#endif


### PR DESCRIPTION
Allow users to run a trigger when RAS mc_event occurs, The mc_event trigger is separated into CE trigger and UE trigger, this is because CE is more frequent than UE, and the CE trigger will lead to more performance hits. Users can choose different triggers for CE/UE to reduce this effect.

Users can config trigger in /etc/sysconfig/rasdaemon:

    TRIGGER_DIR: The trigger diretory
    MC_CE_TRIGGER: The script executed when corrected error occurs.
    MC_UE_TRIGGER: The script executed when uncorrected error occurs.

No script will be executed if MC_CE_TRIGGER/MC_UE_TRIGGER is null.