### PR TITLE
rasdaemon: labels/apple macpro 2008 3,1 dimm1-4 riser A&B

### DIFF
--- a/labels/apple
+++ b/labels/apple
@@ -1,0 +1,17 @@
+# RASDAEMON Motherboard DIMM labels Database file.
+#
+#  Vendor-name and model-name are found from the program 'dmidecode'
+#  labels are found from the silk screen on the motherboard.
+#
+#Vendor: <vendor-name>
+#  Model: <model-name>
+#    <label>: <mc>.<branch>.<channel>.<slot>
+#
+
+Vendor: Apple Inc.
+  Model: Mac-F42C88C8
+    DIMM1_RA: 0.1.0.0; DIMM2_RA: 0.1.1.0;
+    DIMM3_RA: 0.1.0.1; DIMM4_RA: 0.1.1.1;
+
+    DIMM1_RB: 0.0.0.0; DIMM2_RB: 0.0.1.0;
+    DIMM3_RB: 0.0.0.1; DIMM4_RB: 0.0.1.1;


### PR DESCRIPTION
For the Apple Mac Pro 3,1( 2008) Mac-F42C88C8 these are the correct labels for the DIMM numbers 1-4 on each DIMM Riser A&B for a total of 8 DIMMS. 

The upper Riser is called A the lower Riser is called B. The so called `slot 2` and `slot 3` found by `ras-mc-ctl --layout` are not available as slots or risers on the motherboard. The `ras-mc-ctl --guess-labels` showed right labels but the DIMM numbers are indistinguishable, however  this commit is needed to link them to the right memory location.

```
$ ras-mc-ctl --layout
       +-----------------------------------------------+
       |                      mc0                      |
       |        branch0        |        branch1        |
       | channel0  | channel1  | channel0  | channel1  |
-------+-----------------------------------------------+
slot3: |     0 MB  |     0 MB  |     0 MB  |     0 MB  |
slot2: |     0 MB  |     0 MB  |     0 MB  |     0 MB  |
-------+-----------------------------------------------+
slot1: |  2048 MB  |  2048 MB  |  2048 MB  |  2048 MB  |
slot0: |  8192 MB  |  8192 MB  |  4096 MB  |  4096 MB  |
-------+-----------------------------------------------+

$ ras-mc-ctl --guess-labels
memory stick 'DIMM 1' is located at 'DIMM Riser B'
memory stick 'DIMM 2' is located at 'DIMM Riser B'
memory stick 'DIMM 1' is located at 'DIMM Riser A'
memory stick 'DIMM 2' is located at 'DIMM Riser A'
memory stick 'DIMM 3' is located at 'DIMM Riser B'
memory stick 'DIMM 4' is located at 'DIMM Riser B'
memory stick 'DIMM 3' is located at 'DIMM Riser A'
memory stick 'DIMM 4' is located at 'DIMM Riser A'
```

Signed-off-by: Walter Sonius <walterav1984@gmail.com>