### PR TITLE
labels/supermicro: add Supermicro X11DPi-N(T)

### DIFF
--- a/labels/supermicro
+++ b/labels/supermicro
@@ -112,7 +112,25 @@ Vendor: Supermicro
     P2-DIMMD1: 3.0.0;
     P2-DIMME1: 3.1.0;
     P2-DIMMF1: 3.2.0;
-  
+
+  Model: X11DPi-N, X11DPi-NT
+    P1-DIMMA1: 0.0.0;
+    P1-DIMMA2: 0.0.1;
+    P1-DIMMB1: 0.1.0;
+    P1-DIMMC1: 0.2.0;
+    P1-DIMMD1: 1.0.0;
+    P1-DIMMD2: 1.0.1;
+    P1-DIMME1: 1.1.0;
+    P1-DIMMF1: 1.2.0;
+    P2-DIMMA1: 2.0.0;
+    P2-DIMMA2: 2.0.1;
+    P2-DIMMB1: 2.1.0;
+    P2-DIMMC1: 2.2.0;
+    P2-DIMMD1: 3.0.0;
+    P2-DIMMD2: 3.0.1;
+    P2-DIMME1: 3.1.0;
+    P2-DIMMF1: 3.2.0;
+
   Model: X11SPM-F, X11SPM-TF, X11SPM-TPF
     DIMMA1: 0.0.0;
     DIMMB1: 0.1.0;


### PR DESCRIPTION
Add labels for Supermicro X11DPi-N and X11DPi-NT motherboards.

I have tested this on a X11DPi-NT system with four DIMM modules with the latest BIOS applied to the motherboard.
I swapped the modules to different slots, so everything should be reported correctly:
```
root@pve:~# ras-mc-ctl --mainboard
ras-mc-ctl: mainboard: Supermicro model X11DPi-NT
root@pve:~# ras-mc-ctl --print-labels
LOCATION                            CONFIGURED LABEL     SYSFS CONTENTS      
mc0 channel 0 slot 0                P1-DIMMA1            P1-DIMMA1           
                                    P1-DIMMA2            0:0:1 missing       
                                    P1-DIMMB1            0:1:0 missing       
                                    P1-DIMMC1            0:2:0 missing       
mc1 channel 0 slot 0                P1-DIMMD1            P1-DIMMD1           
                                    P1-DIMMD2            1:0:1 missing       
                                    P1-DIMME1            1:1:0 missing       
                                    P1-DIMMF1            1:2:0 missing       
mc2 channel 0 slot 0                P2-DIMMA1            P2-DIMMA1           
                                    P2-DIMMA2            2:0:1 missing       
                                    P2-DIMMB1            2:1:0 missing       
                                    P2-DIMMC1            2:2:0 missing       
mc3 channel 0 slot 0                P2-DIMMD1            P2-DIMMD1           
                                    P2-DIMMD2            3:0:1 missing       
                                    P2-DIMME1            3:1:0 missing       
                                    P2-DIMMF1            3:2:0 missing       

root@pve:~# uname -a
Linux pve 6.5.11-7-pve #1 SMP PREEMPT_DYNAMIC PMX 6.5.11-7 (2023-12-05T09:44Z) x86_64 GNU/Linux
root@pve:~# cat /sys/devices/virtual/dmi/id/bios_date 
08/09/2023
root@pve:~# cat /sys/devices/virtual/dmi/id/bios_version 
4.0
root@pve:~# 
```