### PR TITLE
rasdaemon: labels/apple add MacPro 1,1 and 2,1 models

### DIFF
--- a/labels/apple
+++ b/labels/apple
@@ -8,6 +8,22 @@
 #    <label>: <mc>.<branch>.<channel>.<slot>
 #
 
+Vendor: Apple Computer, Inc.
+  Model: Mac-F4208DC8
+    DIMM1_RA: 0.0.0.0; DIMM2_RA: 0.0.1.0;
+    DIMM3_RA: 0.0.0.1; DIMM4_RA: 0.0.1.1;
+    
+    DIMM1_RB: 0.1.0.0; DIMM2_RB: 0.1.1.0;
+    DIMM3_RB: 0.1.0.1; DIMM4_RB: 0.1.1.1;
+
+Vendor: Apple Inc.
+  Model: Mac-F4208DA9
+    DIMM1_RA: 0.0.0.0; DIMM2_RA: 0.0.1.0;
+    DIMM3_RA: 0.0.0.1; DIMM4_RA: 0.0.1.1;
+    
+    DIMM1_RB: 0.1.0.0; DIMM2_RB: 0.1.1.0;
+    DIMM3_RB: 0.1.0.1; DIMM4_RB: 0.1.1.1;
+
 Vendor: Apple Inc.
   Model: Mac-F42C88C8
     DIMM1_RA: 0.1.0.0; DIMM2_RA: 0.1.1.0;


### PR DESCRIPTION
For the Apple MacPro 1,1 (Mac-F4208DC8) and MacPro 2,1 (Mac-F4208DA9) these are the correct labels for the DIMM numbers 1-4 on each DIMM Riser A&B for a total of 8 DIMMS. The MacPro 1,1 vendor is actually called "Apple Computer, Inc." vs "Apple Inc." for the MacPro 2,1 and 3,1. Another note is that the MacPro 1,1 and 2,1 require the kernel parameter `noefi` for their efi32 firmware to boot a 64bit kernel using the `debian-12.4.0-amd64-netinst.iso`.

The upper Riser is called A the lower Riser is called B. However compared to MacPro 3,1 the riser labels A & B are branch swapped on the memory controller on MacPro1,1 and 2,1 not its physical location in the case (double checked it)! The so called `slot 2` and `slot 3` found by `ras-mc-ctl --layout` are not available as slots or risers on the motherboard. The `ras-mc-ctl --guess-labels` showed right labels but the DIMM numbers are indistinguishable, however this commit is needed to link them to the right memory location.

```
$ sudo dmesg | grep MacPro
[    0.000000] DMI: Apple Computer, Inc. MacPro1,1/Mac-F4208DC8, BIOS     MP11.88Z.005C.B08.0707021221 07/02/07

$ sudo dmesg | grep MacPro
[    0.000000] DMI: Apple Computer, Inc. MacPro2,1/Mac-F4208DA9, BIOS     MP21.88Z.007F.B08.0709061728 09/06/07

$ lsmod | grep edac #i5000 module is missing on newer ubuntu kernel builds...
i5000_edac             20480  0

$ sudo ras-mc-ctl --mainboard
ras-mc-ctl: mainboard: Apple Computer, Inc. model Mac-F4208DC8

$ sudo ras-mc-ctl --mainboard
ras-mc-ctl: mainboard: Apple Inc. model Mac-F4208DA9

$ sudo ras-mc-ctl --layout
       +-----------------------------------------------+
       |                      mc0                      |
       |        branch0        |        branch1        |
       | channel0  | channel1  | channel0  | channel1  |
-------+-----------------------------------------------+
slot3: |     0 MB  |     0 MB  |     0 MB  |     0 MB  |
slot2: |     0 MB  |     0 MB  |     0 MB  |     0 MB  |
-------+-----------------------------------------------+
slot1: |  2048 MB  |  2048 MB  |  2048 MB  |  2048 MB  |
slot0: |  2048 MB  |  2048 MB  |  2048 MB  |  2048 MB  |
-------+-----------------------------------------------+

$ sudo ras-mc-ctl --layout #edited with dimm labels
       +-----------------------------------------------+
       |                      mc0                      |
       |        branch0        |        branch1        |
       | channel0  | channel1  | channel0  | channel1  |
-------+-----------------------------------------------+
slot3: |     0 MB  |     0 MB  |     0 MB  |     0 MB  |
slot2: |     0 MB  |     0 MB  |     0 MB  |     0 MB  |
-------+-----------------------------------------------+
slot1: |  DIMM3RA  |  DIMM4RA  |  DIMM3RB  |  DIMM4RB  |
slot0: |  DIMM1RA  |  DIMM2RA  |  DIMM1RB  |  DIMM2RB  |
-------+-----------------------------------------------+

$ sudo ras-mc-ctl --error-count
Label                      	CE	UE
mc#0branch#0channel#1slot#0	0	0
mc#0branch#1channel#0slot#0	0	0
mc#0branch#0channel#0slot#1	0	0
mc#0branch#1channel#1slot#1	0	0
mc#0branch#1channel#1slot#0	0	0
mc#0branch#0channel#0slot#0	0	0
mc#0branch#1channel#0slot#1	0	0
mc#0branch#0channel#1slot#1	0	0

$ sudo ras-mc-ctl --guess-labels
memory stick 'DIMM 1' is located at 'DIMM Riser A'
memory stick 'DIMM 2' is located at 'DIMM Riser A'
memory stick 'DIMM 1' is located at 'DIMM Riser B'
memory stick 'DIMM 2' is located at 'DIMM Riser B'
memory stick 'DIMM 3' is located at 'DIMM Riser A'
memory stick 'DIMM 4' is located at 'DIMM Riser A'
memory stick 'DIMM 3' is located at 'DIMM Riser B'
memory stick 'DIMM 4' is located at 'DIMM Riser B'

$ sudo ras-mc-ctl --print-labels #edited labels but not registered yet
LOCATION                            CONFIGURED LABEL     SYSFS CONTENTS      
mc0 branch 0 channel 0 slot 0       DIMM1_RA             mc#0branch#0channel#0slot#0
mc0 branch 0 channel 0 slot 1       DIMM3_RA             mc#0branch#0channel#0slot#1
mc0 branch 0 channel 1 slot 0       DIMM2_RA             mc#0branch#0channel#1slot#0
mc0 branch 0 channel 1 slot 1       DIMM4_RA             mc#0branch#0channel#1slot#1
mc0 branch 1 channel 0 slot 0       DIMM1_RB             mc#0branch#1channel#0slot#0
mc0 branch 1 channel 0 slot 1       DIMM3_RB             mc#0branch#1channel#0slot#1
mc0 branch 1 channel 1 slot 0       DIMM2_RB             mc#0branch#1channel#1slot#0
mc0 branch 1 channel 1 slot 1       DIMM4_RB             mc#0branch#1channel#1slot#1

$ sudo ras-mc-ctl --register-labels
$ sudo ras-mc-ctl --print-labels
LOCATION                            CONFIGURED LABEL     SYSFS CONTENTS      
mc0 branch 0 channel 0 slot 0       DIMM1_RA             DIMM1_RA            
mc0 branch 0 channel 0 slot 1       DIMM3_RA             DIMM3_RA            
mc0 branch 0 channel 1 slot 0       DIMM2_RA             DIMM2_RA            
mc0 branch 0 channel 1 slot 1       DIMM4_RA             DIMM4_RA            
mc0 branch 1 channel 0 slot 0       DIMM1_RB             DIMM1_RB            
mc0 branch 1 channel 0 slot 1       DIMM3_RB             DIMM3_RB            
mc0 branch 1 channel 1 slot 0       DIMM2_RB             DIMM2_RB            
mc0 branch 1 channel 1 slot 1       DIMM4_RB             DIMM4_RB 
```

Signed-off-by: Walter Sonius [walterav1984@gmail.com](mailto:walterav1984@gmail.com)