### PR TITLE
rasdaemon: Add error decoding for MCA_CTL_SMU extended bits

### DIFF
--- a/ras-mce-handler.h
+++ b/ras-mce-handler.h
@@ -125,6 +125,7 @@ int set_intel_imc_log(enum cputype cputype, unsigned ncpus);
 /* Undertake AMD SMCA Error Decoding */
 void decode_smca_error(struct mce_event *e, struct mce_priv *m);
 void amd_decode_errcode(struct mce_event *e);
+void smca_smu2_ext_err_desc(void);
 
 /* Per-CPU-type decoders for Intel CPUs */
 void p4_decode_model(struct mce_event *e);


### PR DESCRIPTION
Enable error decoding support for the newly added extended error bit descriptions from MCA_CTL_SMU.
b'0:11 can be decoded from existing array smca_smu2_mce_desc. Define a function to append the newly defined b'58:62 to the smca_smu2_mce_desc. This reduces the maintaining Reserved bits from b'12:57 in the code.