### PR TITLE
Use block_rq_error if RHEL >= 9.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,19 @@ AS_IF([test "x$enable_diskerror" = "xyes" || test "x$enable_all" = "xyes"], [
 AM_CONDITIONAL([WITH_DISKERROR], [test x$enable_diskerror = xyes || test x$enable_all = xyes])
 AM_COND_IF([WITH_DISKERROR], [USE_DISKERROR="yes"], [USE_DISKERROR="no"])
 
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
+#ifdef RHEL_RELEASE_CODE
+#if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 1)
+# error kernel too old
+#endif
+#else
+# error kernel too old
+#endif
+#endif
+]])], [AC_DEFINE(HAVE_BLK_RQ_ERROR,1,"have block_rq_error tracepoint")])
+
 AC_ARG_ENABLE([memory_failure],
     AS_HELP_STRING([--enable-memory-failure], [enable memory failure events (currently experimental)]))
 

--- a/ras-events.c
+++ b/ras-events.c
@@ -28,7 +28,6 @@
 #include <sys/poll.h>
 #include <signal.h>
 #include <sys/signalfd.h>
-#include <linux/version.h>
 #include <traceevent/kbuffer.h>
 #include <traceevent/event-parse.h>
 #include "ras-mc-handler.h"
@@ -250,7 +249,7 @@ int toggle_ras_mc_event(int enable)
 #endif
 
 #ifdef HAVE_DISKERROR
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
+#ifdef HAVE_BLK_RQ_ERROR
 	rc |= __toggle_ras_mc_event(ras, "block", "block_rq_error", enable);
 #else
 	rc |= __toggle_ras_mc_event(ras, "block", "block_rq_complete", enable);
@@ -277,7 +276,7 @@ free_ras:
 	return rc;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
+#ifndef HAVE_BLK_RQ_ERROR
 /*
  * Set kernel filter. libtrace doesn't provide an API for setting filters
  * in kernel, we have to implement it here.
@@ -1014,7 +1013,7 @@ int handle_ras_events(int record_events)
 #endif
 
 #ifdef HAVE_DISKERROR
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
+#ifdef HAVE_BLK_RQ_ERROR
 	rc = add_event_handler(ras, pevent, page_size, "block",
 			       "block_rq_error", ras_diskerror_event_handler,
 				NULL, DISKERROR_EVENT);


### PR DESCRIPTION
The commit introducing block_rq_error tracepoint
has been backported in RHEL 9.1, so improve the check for block_rq_error presence to use it.