### PR TITLE
rasdaemon: ras-mc-ctl: Do not try to find modprobe

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -39,7 +39,6 @@ my $dbname      = "@RASSTATEDIR@/@RAS_DB_FNAME@";
 my $prefix      = "@prefix@";
 my $sysconfdir  = "@sysconfdir@";
 my $dmidecode   = find_prog ("dmidecode");
-my $modprobe    = find_prog ("modprobe")  or exit (1);
 
 my $has_aer = 0;
 my $has_arm = 0;


### PR DESCRIPTION
It is not used and prevents ras-mc-ctl.service from starting on Fedora when SELinux is in Enforcing mode.

Resolves: rhbz#1836861
Resolves: https://github.com/fedora-selinux/selinux-policy/issues/2054
Resolves: https://github.com/mchehab/rasdaemon/issues/79