### PR TITLE
Fix ras-mc-ctl bug and add support for parsing the new fields added to MCE tracepoint

### DIFF
--- a/ras-mce-handler.c
+++ b/ras-mce-handler.c
@@ -375,6 +375,9 @@ static void report_mce_event(struct ras_events *ras,
 	if (e->ppin)
 		trace_seq_printf(s, ", ppin= %llx", (long long)e->ppin);
 
+	if (e->microcode)
+		trace_seq_printf(s, ", microcode= %x", e->microcode);
+
 	if (!e->vdata_len)
 		return;
 
@@ -572,6 +575,10 @@ int ras_mce_event_handler(struct trace_seq *s,
 	/* Get PPIN */
 	if (!tep_get_field_val(s, event, "ppin", record, &val, 1))
 		e.ppin = val;
+
+	/* Get Microcode Revision */
+	if (!tep_get_field_val(s, event, "microcode", record, &val, 1))
+		e.microcode = val;
 
 	/* Get Vendor-specfic Data, if any */
 	e.vdata = tep_get_field_raw(s, event, "v_data", record, &e.vdata_len, 1);

--- a/ras-mce-handler.c
+++ b/ras-mce-handler.c
@@ -372,6 +372,9 @@ static void report_mce_event(struct ras_events *ras,
 
 	trace_seq_printf(s, ", apicid= %x", e->apicid);
 
+	if (e->ppin)
+		trace_seq_printf(s, ", ppin= %llx", (long long)e->ppin);
+
 	if (!e->vdata_len)
 		return;
 
@@ -565,6 +568,10 @@ int ras_mce_event_handler(struct trace_seq *s,
 	if (tep_get_field_val(s, event, "ipid", record, &val, 1) < 0)
 		return -1;
 	e.ipid = val;
+
+	/* Get PPIN */
+	if (!tep_get_field_val(s, event, "ppin", record, &val, 1))
+		e.ppin = val;
 
 	/* Get Vendor-specfic Data, if any */
 	e.vdata = tep_get_field_raw(s, event, "v_data", record, &e.vdata_len, 1);

--- a/ras-mce-handler.h
+++ b/ras-mce-handler.h
@@ -75,6 +75,7 @@ struct mce_event {
 	uint8_t		cpuvendor;
 	uint64_t        synd;   /* MCA_SYND MSR: only valid on SMCA systems */
 	uint64_t        ipid;   /* MCA_IPID MSR: only valid on SMCA systems */
+	uint64_t 	ppin;
 	int32_t		vdata_len;
 	const uint64_t	*vdata;
 

--- a/ras-mce-handler.h
+++ b/ras-mce-handler.h
@@ -76,6 +76,7 @@ struct mce_event {
 	uint64_t        synd;   /* MCA_SYND MSR: only valid on SMCA systems */
 	uint64_t        ipid;   /* MCA_IPID MSR: only valid on SMCA systems */
 	uint64_t 	ppin;
+	uint32_t	microcode;
 	int32_t		vdata_len;
 	const uint64_t	*vdata;
 

--- a/ras-record.c
+++ b/ras-record.c
@@ -330,19 +330,20 @@ static const struct db_fields mce_record_fields[] = {
 		{ .name = "ip",			.type = "INTEGER" },
 		{ .name = "tsc",			.type = "INTEGER" },
 		{ .name = "walltime",		.type = "INTEGER" },
-		{ .name = "cpu",			.type = "INTEGER" }, // 10
+		{ .name = "ppin",			.type = "INTEGER" }, // 10
+		{ .name = "cpu",			.type = "INTEGER" },
 		{ .name = "cpuid",		.type = "INTEGER" },
 		{ .name = "apicid",		.type = "INTEGER" },
 		{ .name = "socketid",		.type = "INTEGER" },
-		{ .name = "cs",			.type = "INTEGER" },
-		{ .name = "bank",			.type = "INTEGER" }, //15
+		{ .name = "cs",			.type = "INTEGER" }, // 15
+		{ .name = "bank",			.type = "INTEGER" },
 		{ .name = "cpuvendor",		.type = "INTEGER" },
 
 		/* Parsed data - will likely change */
 		{ .name = "bank_name",		.type = "TEXT" },
 		{ .name = "error_msg",		.type = "TEXT" },
-		{ .name = "mcgstatus_msg",	.type = "TEXT" },
-		{ .name = "mcistatus_msg",	.type = "TEXT" }, // 20
+		{ .name = "mcgstatus_msg",	.type = "TEXT" },// 20
+		{ .name = "mcistatus_msg",	.type = "TEXT" },
 		{ .name = "mcastatus_msg",	.type = "TEXT" },
 		{ .name = "user_action",		.type = "TEXT" },
 		{ .name = "mc_location",		.type = "TEXT" },
@@ -372,21 +373,22 @@ int ras_store_mce_record(struct ras_events *ras, struct mce_event *ev)
 	sqlite3_bind_int64(priv->stmt_mce_record,  7, ev->ip);
 	sqlite3_bind_int64(priv->stmt_mce_record,  8, ev->tsc);
 	sqlite3_bind_int64(priv->stmt_mce_record,  9, ev->walltime);
-	sqlite3_bind_int   (priv->stmt_mce_record, 10, ev->cpu);
-	sqlite3_bind_int   (priv->stmt_mce_record, 11, ev->cpuid);
-	sqlite3_bind_int   (priv->stmt_mce_record, 12, ev->apicid);
-	sqlite3_bind_int   (priv->stmt_mce_record, 13, ev->socketid);
-	sqlite3_bind_int   (priv->stmt_mce_record, 14, ev->cs);
-	sqlite3_bind_int   (priv->stmt_mce_record, 15, ev->bank);
-	sqlite3_bind_int   (priv->stmt_mce_record, 16, ev->cpuvendor);
+	sqlite3_bind_int64(priv->stmt_mce_record,  10, ev->ppin);
+	sqlite3_bind_int   (priv->stmt_mce_record, 11, ev->cpu);
+	sqlite3_bind_int   (priv->stmt_mce_record, 12, ev->cpuid);
+	sqlite3_bind_int   (priv->stmt_mce_record, 13, ev->apicid);
+	sqlite3_bind_int   (priv->stmt_mce_record, 14, ev->socketid);
+	sqlite3_bind_int   (priv->stmt_mce_record, 15, ev->cs);
+	sqlite3_bind_int   (priv->stmt_mce_record, 16, ev->bank);
+	sqlite3_bind_int   (priv->stmt_mce_record, 17, ev->cpuvendor);
 
-	sqlite3_bind_text(priv->stmt_mce_record, 17, ev->bank_name, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 18, ev->error_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 19, ev->mcgstatus_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 20, ev->mcistatus_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 21, ev->mcastatus_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 22, ev->user_action, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 23, ev->mc_location, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 18, ev->bank_name, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 19, ev->error_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 20, ev->mcgstatus_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 21, ev->mcistatus_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 22, ev->mcastatus_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 23, ev->user_action, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 24, ev->mc_location, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_mce_record);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)

--- a/ras-record.c
+++ b/ras-record.c
@@ -338,11 +338,12 @@ static const struct db_fields mce_record_fields[] = {
 		{ .name = "cs",			.type = "INTEGER" }, // 15
 		{ .name = "bank",			.type = "INTEGER" },
 		{ .name = "cpuvendor",		.type = "INTEGER" },
+		{ .name = "microcode",      .type = "INTEGER" },
 
 		/* Parsed data - will likely change */
 		{ .name = "bank_name",		.type = "TEXT" },
-		{ .name = "error_msg",		.type = "TEXT" },
-		{ .name = "mcgstatus_msg",	.type = "TEXT" },// 20
+		{ .name = "error_msg",		.type = "TEXT" }, // 20
+		{ .name = "mcgstatus_msg",	.type = "TEXT" },
 		{ .name = "mcistatus_msg",	.type = "TEXT" },
 		{ .name = "mcastatus_msg",	.type = "TEXT" },
 		{ .name = "user_action",		.type = "TEXT" },
@@ -381,14 +382,15 @@ int ras_store_mce_record(struct ras_events *ras, struct mce_event *ev)
 	sqlite3_bind_int   (priv->stmt_mce_record, 15, ev->cs);
 	sqlite3_bind_int   (priv->stmt_mce_record, 16, ev->bank);
 	sqlite3_bind_int   (priv->stmt_mce_record, 17, ev->cpuvendor);
+	sqlite3_bind_int   (priv->stmt_mce_record, 18, ev->microcode);
 
-	sqlite3_bind_text(priv->stmt_mce_record, 18, ev->bank_name, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 19, ev->error_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 20, ev->mcgstatus_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 21, ev->mcistatus_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 22, ev->mcastatus_msg, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 23, ev->user_action, -1, NULL);
-	sqlite3_bind_text(priv->stmt_mce_record, 24, ev->mc_location, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 19, ev->bank_name, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 20, ev->error_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 21, ev->mcgstatus_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 22, ev->mcistatus_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 23, ev->mcastatus_msg, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 24, ev->user_action, -1, NULL);
+	sqlite3_bind_text(priv->stmt_mce_record, 25, ev->mc_location, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_mce_record);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1329,7 +1329,7 @@ sub errors
 {
     require DBI;
     my ($query, $query_handle, $id, $time, $devname, $count, $type, $msg, $label, $mc, $top, $mid, $low, $addr, $grain, $syndrome, $detail, $out);
-    my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location);
+    my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $ppin, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location);
     my ($timestamp, $etype, $severity, $etype_string, $severity_string, $fru_id, $fru_text, $cper_data);
     my ($bus_name, $dev_name, $driver_name, $reporter_name);
     my ($dev, $sector, $nr_sector, $error, $rwbs, $cmd);
@@ -1497,10 +1497,10 @@ sub errors
 
     # MCE mce_record errors
     if ($has_mce == 1) {
-        $query = "select id, timestamp, mcgcap, mcgstatus, status, addr, misc, ip, tsc, walltime, cpu, cpuid, apicid, socketid, cs, bank, cpuvendor, bank_name, error_msg, mcgstatus_msg, mcistatus_msg, mcastatus_msg, user_action, mc_location from mce_record$conf{opt}{since} order by id";
+        $query = "select id, timestamp, mcgcap, mcgstatus, status, addr, misc, ip, tsc, walltime, ppin, cpu, cpuid, apicid, socketid, cs, bank, cpuvendor, bank_name, error_msg, mcgstatus_msg, mcistatus_msg, mcastatus_msg, user_action, mc_location from mce_record$conf{opt}{since} order by id";
         $query_handle = $dbh->prepare($query);
         $query_handle->execute();
-        $query_handle->bind_columns(\($id, $time, $mcgcap,$mcgstatus, $status, $addr, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $msg, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location));
+        $query_handle->bind_columns(\($id, $time, $mcgcap,$mcgstatus, $status, $addr, $misc, $ip, $tsc, $walltime, $ppin, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $msg, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location));
         $out = "";
         while($query_handle->fetch()) {
             $out .= "$id $time error: $msg";
@@ -1519,6 +1519,7 @@ sub errors
 	    $out .= sprintf ", ip=0x%08x", $ip if ($ip);
 	    $out .= sprintf ", tsc=0x%08x", $tsc if ($tsc);
 	    $out .= sprintf ", walltime=0x%08x", $walltime if ($walltime);
+		$out .= sprintf ", ppin=0x%08x", $ppin if ($ppin);
 	    $out .= sprintf ", cpu=0x%08x", $cpu if ($cpu);
 	    $out .= sprintf ", cpuid=0x%08x", $cpuid if ($cpuid);
 	    $out .= sprintf ", apicid=0x%08x", $apicid if ($apicid);

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1329,7 +1329,7 @@ sub errors
 {
     require DBI;
     my ($query, $query_handle, $id, $time, $devname, $count, $type, $msg, $label, $mc, $top, $mid, $low, $addr, $grain, $syndrome, $detail, $out);
-    my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $ppin, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location);
+    my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $ppin, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $microcode, $bank_name, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location);
     my ($timestamp, $etype, $severity, $etype_string, $severity_string, $fru_id, $fru_text, $cper_data);
     my ($bus_name, $dev_name, $driver_name, $reporter_name);
     my ($dev, $sector, $nr_sector, $error, $rwbs, $cmd);
@@ -1497,10 +1497,10 @@ sub errors
 
     # MCE mce_record errors
     if ($has_mce == 1) {
-        $query = "select id, timestamp, mcgcap, mcgstatus, status, addr, misc, ip, tsc, walltime, ppin, cpu, cpuid, apicid, socketid, cs, bank, cpuvendor, bank_name, error_msg, mcgstatus_msg, mcistatus_msg, mcastatus_msg, user_action, mc_location from mce_record$conf{opt}{since} order by id";
+        $query = "select id, timestamp, mcgcap, mcgstatus, status, addr, misc, ip, tsc, walltime, ppin, cpu, cpuid, apicid, socketid, cs, bank, cpuvendor, microcode, bank_name, error_msg, mcgstatus_msg, mcistatus_msg, mcastatus_msg, user_action, mc_location from mce_record$conf{opt}{since} order by id";
         $query_handle = $dbh->prepare($query);
         $query_handle->execute();
-        $query_handle->bind_columns(\($id, $time, $mcgcap,$mcgstatus, $status, $addr, $misc, $ip, $tsc, $walltime, $ppin, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $msg, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location));
+        $query_handle->bind_columns(\($id, $time, $mcgcap,$mcgstatus, $status, $addr, $misc, $ip, $tsc, $walltime, $ppin, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $microcode, $bank_name, $msg, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location));
         $out = "";
         while($query_handle->fetch()) {
             $out .= "$id $time error: $msg";
@@ -1526,6 +1526,7 @@ sub errors
 	    $out .= sprintf ", socketid=0x%08x", $socketid if ($socketid);
 	    $out .= sprintf ", cs=0x%08x", $cs if ($cs);
 	    $out .= sprintf ", bank=0x%08x", $bank if ($bank);
+		$out .= sprintf ", microcode=0x%08x", $microcode if ($microcode);
 
 	    $out .= "\n";
         }

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1329,7 +1329,7 @@ sub errors
 {
     require DBI;
     my ($query, $query_handle, $id, $time, $devname, $count, $type, $msg, $label, $mc, $top, $mid, $low, $addr, $grain, $syndrome, $detail, $out);
-    my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $mcgstatus_msg, $mcistatus_msg, $user_action, $mc_location);
+    my ($mcgcap,$mcgstatus, $status, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location);
     my ($timestamp, $etype, $severity, $etype_string, $severity_string, $fru_id, $fru_text, $cper_data);
     my ($bus_name, $dev_name, $driver_name, $reporter_name);
     my ($dev, $sector, $nr_sector, $error, $rwbs, $cmd);
@@ -1497,10 +1497,10 @@ sub errors
 
     # MCE mce_record errors
     if ($has_mce == 1) {
-        $query = "select id, timestamp, mcgcap, mcgstatus, status, addr, misc, ip, tsc, walltime, cpu, cpuid, apicid, socketid, cs, bank, cpuvendor, bank_name, error_msg, mcgstatus_msg, mcistatus_msg, user_action, mc_location from mce_record$conf{opt}{since} order by id";
+        $query = "select id, timestamp, mcgcap, mcgstatus, status, addr, misc, ip, tsc, walltime, cpu, cpuid, apicid, socketid, cs, bank, cpuvendor, bank_name, error_msg, mcgstatus_msg, mcistatus_msg, mcastatus_msg, user_action, mc_location from mce_record$conf{opt}{since} order by id";
         $query_handle = $dbh->prepare($query);
         $query_handle->execute();
-        $query_handle->bind_columns(\($id, $time, $mcgcap,$mcgstatus, $status, $addr, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $msg, $mcgstatus_msg, $mcistatus_msg, $user_action, $mc_location));
+        $query_handle->bind_columns(\($id, $time, $mcgcap,$mcgstatus, $status, $addr, $misc, $ip, $tsc, $walltime, $cpu, $cpuid, $apicid, $socketid, $cs, $bank, $cpuvendor, $bank_name, $msg, $mcgstatus_msg, $mcistatus_msg, $mcastatus_msg, $user_action, $mc_location));
         $out = "";
         while($query_handle->fetch()) {
             $out .= "$id $time error: $msg";
@@ -1508,6 +1508,7 @@ sub errors
 	    $out .= ", bank $bank_name" if ($bank_name);
 	    $out .= ", mcg $mcgstatus_msg" if ($mcgstatus_msg);
 	    $out .= ", mci $mcistatus_msg" if ($mcistatus_msg);
+		$out .= ", mca $mcastatus_msg" if ($mcastatus_msg);
 	    $out .= ", $mc_location" if ($mc_location);
 	    $out .= ", $user_action" if ($user_action);
 	    $out .= sprintf ", mcgcap=0x%08x", $mcgcap if ($mcgcap);


### PR DESCRIPTION
This set fixes an issue with ras-mc-ctl utility and adds support in the rasdaemon to parse the PPIN and Microcode fields which are now being exported through the MCE tracepoint (link below).

The first patch fixes the ras-mc-ctl utility issue in which even though the mcastatus_msg string is being added to the database by the rasdaemon, the same is not outputted by the utility.

The second patch adds support to parse the PPIN field of MCE tracepoint. The patch also supports storing the field in the SQLite database and outputting through ras-mc-ctl utility.

The third patch adds support to parse the Microcode field of MCE tracepoint. The patch also supports storing the field in the SQLite database and outputting through ras-mc-ctl utility.

The three patches are being submitted as a set since patches 2 and 3 might encounter conflicts in merging without patch 1.

Link for the PPIN and Microcode fields added to the MCE tracepoint:

https://lore.kernel.org/linux-edac/20240401171455.1737976-1-avadhut.naik@amd.com/T/#mec02926ae30a92161160a2f9649b9e2b419701c0