### PR TITLE
rasdaemon: Fix for vendor errors are not recorded in the SQLite datab…

### DIFF
--- a/ras-non-standard-handler.h
+++ b/ras-non-standard-handler.h
@@ -19,6 +19,7 @@
 
 struct ras_ns_ev_decoder {
 	struct ras_ns_ev_decoder *next;
+	uint16_t ref_count;
 	const char *sec_type;
 	int (*add_table)(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder);
 	int (*decode)(struct ras_events *ras, struct ras_ns_ev_decoder *ev_decoder,


### PR DESCRIPTION
…ase if some cpus are offline

Fix for vendor errors are not recorded in the SQLite database if some cpus are offline at the system start.

Issue:

This issue is reproducible by offline some cpus, run ./rasdaemon -f --record & and
inject vendor specific error supported in the rasdaemon.

Reason:

When the system starts with some of the cpus offline and then run the rasdaemon, read_ras_event_all_cpus() exit with error and switch to the multi thread way. However read() in read_ras_event() return error in threads for each of the offline CPUs and does clean up including calling ras_ns_finalize_vendor_tables(), which invokes sqlite3_finalize() on vendor tables created. Thus the vendor error data does not stored in the SQLite database when such error is reported next time.

Solution:

In ras_ns_add_vendor_tables() and ras_ns_finalize_vendor_tables() use reference count and close vendor tables which created in ras_ns_add_vendor_tables() based on the reference count.

Reported-by: Junhao He <hejunhao3@huawei.com>