### PR TITLE
rasdaemon: Add error decoding for MCA_CTL_SMU extended bits

### DIFF
--- a/mce-amd-smca.c
+++ b/mce-amd-smca.c
@@ -434,6 +434,12 @@ static const char * smca_smu2_mce_desc[64] = {
 	"Instruction Tag Cache Bank B ECC or parity error",
 	"System Hub Read Buffer ECC or parity error",
 	"PHY RAS ECC Error",
+	[12 ... 57] = "Reserved",
+	"A correctable error from a GFX Sub-IP",
+	"A fatal error from a GFX Sub-IP",
+	"Reserved",
+	"A poison error from a GFX Sub-IP",
+	"Reserved",
 };
 
 static const char * smca_smu2_ext_mce_desc[] = {


### PR DESCRIPTION
#144 Addressed review comments. #144 can be closed