### PR TITLE
ras-events: fix -d option to work again

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -193,7 +193,8 @@ static int __toggle_ras_mc_event(struct ras_events *ras,
 	int fd, rc;
 	char fname[MAX_PATH + 1];
 
-	enable = is_disabled_event(group, event) ? 0 : 1;
+	if (enable)
+		enable = is_disabled_event(group, event) ? 0 : 1;
 
 	snprintf(fname, sizeof(fname), "%s%s:%s\n",
 		 enable ? "" : "!",


### PR DESCRIPTION
It seems commit 3e9a59a184ca("Add dynamic switch of ras events support.") inadvertedly introduced the change to ignore -d option. Fix this so that -d will disable all trace events at once like before.