### PR TITLE
rasdaemon: Fix mem_fail_event build breakage

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -55,7 +55,9 @@ char *choices_disable;
 
 static const struct event_trigger event_triggers[] = {
 	{ "mc_event", &mc_event_trigger_setup },
+#ifdef HAVE_MEMORY_FAILURE
 	{ "memory_failure_event", &mem_fail_event_trigger_setup },
+#endif
 };
 
 static int get_debugfs_dir(char *tracing_dir, size_t len)


### PR DESCRIPTION
Commit 566a52622b1d ("add mem_fail_event trigger") introduces an event trigger for a memory failure event.

However, if the rasdaemon is not configured with enable-memory-failure, the setup function of the trigger, mem_fail_event_trigger_setup(), will result in an undefined reference linker error when called through setup_event_trigger().

Ensure that the setup function for the trigger is called only when the rasdaemon has been configured with enable-memory-failure.

Fixes: 566a52622b1d ("add mem_fail_event trigger")