### PR TITLE
rasdaemon: Modify support for vendor-specific machine check error inf…

### DIFF
--- a/mce-amd-smca.c
+++ b/mce-amd-smca.c
@@ -993,16 +993,8 @@ void decode_smca_error(struct mce_event *e, struct mce_priv *m)
 			     channel, csrow);
 	}
 
-	if (e->vdata_len) {
-		uint64_t smca_config = e->vdata[2];
-
-		/*
-		 * BIT 9 of the CONFIG register of a few SMCA Bank types indicates
-		 * presence of FRU Text in SYND 1 / 2 registers
-		 */
-		if (smca_config & BIT(9))
-			memcpy(e->frutext, e->vdata, 16);
-	}
+	if (e->vdata_len)
+		memcpy(e->frutext, e->vdata, 16);
 }
 
 int parse_amd_smca_event(struct ras_events *ras, struct mce_event *e)

--- a/ras-mce-handler.c
+++ b/ras-mce-handler.c
@@ -376,20 +376,8 @@ static void report_mce_event(struct ras_events *ras,
 	if (!e->vdata_len)
 		return;
 
-	if (strlen(e->frutext)) {
+	if (strlen(e->frutext))
 		trace_seq_printf(s, ", FRU Text= %s", e->frutext);
-		trace_seq_printf(s, ", Vendor Data= ");
-		for (int i = 2; i < e->vdata_len / 8; i++) {
-			trace_seq_printf(s, "0x%lx", e->vdata[i]);
-			trace_seq_printf(s, " ");
-		}
-	} else {
-		trace_seq_printf(s, ", Vendor Data= ");
-		for (int i = 0; i < e->vdata_len / 8; i++) {
-			trace_seq_printf(s, "0x%lx", e->vdata[i]);
-			trace_seq_printf(s, " ");
-		}
-	}
 
 	/*
 	 * FIXME: The original mcelog userspace tool uses DMI to map from


### PR DESCRIPTION
…ormation

Commit 83a3ced797256d ("rasdaemon: Add support for vendor-specific machine check error information") assumes that MCA_CONFIG MSR will be exported as part of vendor-specific error information through the MCE tracepoint.

The same, however, is not true anymore. MCA_CONFIG MSR will not be exported through the MCE tracepoint. Instead, the data from MCA_SYND1/2 MSRs, exported as vendor-specific error information on newer AMD SOCs, should always be interpreted as FRUText.

Modify the error decoding support accordingly.

Fixes: 83a3ced797256d ("rasdaemon: Add support for vendor-specific machine check error information")