### PR TITLE
rasdaemon: Add page offline support for cxl memory

### DIFF
--- a/ras-page-isolation.c
+++ b/ras-page-isolation.c
@@ -429,6 +429,13 @@ void ras_record_page_error(unsigned long long addr, unsigned int count, time_t t
 	}
 }
 
+void ras_hw_threshold_pageoffline(unsigned long long addr)
+{
+	time_t now = time(NULL);
+
+	ras_record_page_error(addr, threshold.val, now);
+}
+
 /* memory page CE threshold policy ends */
 
 /* memory row CE threshold policy starts */

--- a/ras-page-isolation.h
+++ b/ras-page-isolation.h
@@ -117,6 +117,7 @@ struct isolation {
 void ras_page_account_init(void);
 void ras_record_page_error(unsigned long long addr,
 			   unsigned int count, time_t time);
+void ras_hw_threshold_pageoffline(unsigned long long addr);
 void ras_row_account_init(void);
 void ras_record_row_error(const char *detail, unsigned int count, time_t time,
 			  unsigned long long addr);

--- a/ras-record.h
+++ b/ras-record.h
@@ -206,6 +206,7 @@ struct ras_cxl_general_media_event {
 struct ras_cxl_dram_event {
 	struct ras_cxl_event_common_hdr hdr;
 	uint64_t dpa;
+	uint64_t hpa;
 	uint8_t dpa_flags;
 	uint8_t descriptor;
 	uint8_t type;


### PR DESCRIPTION
CXL Type 3 device implements a threshold for corrected errors as described in CXL 3.1 specification section 8.2.9.2.1.2 and 8.2.9.9.11.3. Device can set the threshold field in the DRAM event descriptor when it detects corrected errors that meet or exceed the threshold value.

This patch is intended to offline pages for corrected memory errors when the device sets the threshold in the DRAM event descriptor. This helps prevent corrected errors from becoming uncorrected.

Record the hpa for given dpa, then do pageoffline for hpa when corrected errors threshold is set.