### PR TITLE
rasdaemon: add DE error type for AMD

### DIFF
--- a/ras-events.h
+++ b/ras-events.h
@@ -76,6 +76,7 @@ struct pthread_data {
 enum hw_event_mc_err_type {
 	HW_EVENT_ERR_CORRECTED,
 	HW_EVENT_ERR_UNCORRECTED,
+	HW_EVENT_ERR_DEFERRED,
 	HW_EVENT_ERR_FATAL,
 	HW_EVENT_ERR_INFO,
 };

--- a/ras-mc-handler.c
+++ b/ras-mc-handler.c
@@ -153,6 +153,9 @@ int ras_mc_event_handler(struct trace_seq *s,
 	case HW_EVENT_ERR_UNCORRECTED:
 		ev.error_type = "Uncorrected";
 		break;
+	case HW_EVENT_ERR_DEFERRED:
+		ev.error_type = "Deferred";
+		break;
 	case HW_EVENT_ERR_FATAL:
 		ev.error_type = "Fatal";
 		break;


### PR DESCRIPTION
hw_event_mc_err_type in kernel include HW_EVENT_ERR_DEFERRED for AMD, add this error type in rasdaemon.