### PR TITLE
rasdaemon: arm: do not print error msg if field not found

### DIFF
--- a/ras-arm-handler.c
+++ b/ras-arm-handler.c
@@ -535,7 +535,7 @@ int ras_arm_event_handler(struct trace_seq *s,
 	trace_seq_printf(s, " psci_state: %d", ev.psci_state);
 
 	/* Upstream Kernels up to version 6.10 don't decode UEFI 2.6+ N.17 table */
-	if (tep_get_field_val(s, event, "pei_len", record, &val, 1) >= 0) {
+	if (tep_get_field_val(s, event, "pei_len", record, &val, 0) >= 0) {
 		bool legacy_patch = false;
 
 		ev.pei_len = val;


### PR DESCRIPTION
Fix output from:
	2024-12-19 13:52:02 +0800 affinity: 0 MPIDR: 0x810c0200 MIDR: 0x481fd010 running_state: 1 psci_state: 0<CANT FIND FIELD pei_len>
to:
	2024-12-19 13:52:02 +0800 affinity: 0 MPIDR: 0x810c0200 MIDR: 0x481fd010 running_state: 1 psci_state: 0