### PR TITLE
Use the right dev_t decoding for diskerror handler

### DIFF
--- a/ras-diskerror-handler.c
+++ b/ras-diskerror-handler.c
@@ -9,17 +9,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/sysmacros.h>
 #include <traceevent/kbuffer.h>
 
 #include "ras-diskerror-handler.h"
 #include "ras-logger.h"
 #include "ras-report.h"
 #include "types.h"
-
-#ifndef __dev_t_defined
-#include <sys/types.h>
-#endif /* __dev_t_defined */
 
 static const struct {
 	int             error;
@@ -60,7 +55,7 @@ int ras_diskerror_event_handler(struct trace_seq *s,
 	time_t now;
 	struct tm *tm;
 	struct diskerror_event ev;
-	dev_t dev;
+	uint32_t dev;
 
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
@@ -84,8 +79,8 @@ int ras_diskerror_event_handler(struct trace_seq *s,
 
 	if (tep_get_field_val(s, event, "dev", record, &val, 1) < 0)
 		return -1;
-	dev = (dev_t)val;
-	if (asprintf(&ev.dev, "%u:%u", major(dev), minor(dev)) < 0)
+	dev = (uint32_t)val;
+	if (asprintf(&ev.dev, "%u:%u", MAJOR(dev), MINOR(dev)) < 0)
 		return -1;
 
 	if (tep_get_field_val(s, event, "sector", record, &val, 1) < 0)

--- a/ras-diskerror-handler.h
+++ b/ras-diskerror-handler.h
@@ -11,6 +11,32 @@
 
 #include "ras-events.h"
 
+/*
+ * Defined in linux/kdev_t.h
+ * Since the encoding with 20 bit mask is not defined in the linux-libc headers,
+ * redefine it here
+ * format:
+ *	field:unsigned short common_type;	offset:0;	size:2;	signed:0;
+ *	field:unsigned char common_flags;	offset:2;	size:1;	signed:0;
+ *	field:unsigned char common_preempt_count;	offset:3;	size:1;	signed:0;
+ *	field:int common_pid;	offset:4;	size:4;	signed:1;
+ *
+ *	field:dev_t dev;	offset:8;	size:4;	signed:0;
+ *	field:sector_t sector;	offset:16;	size:8;	signed:0;
+ *	field:unsigned int nr_sector;	offset:24;	size:4;	signed:0;
+ *	field:int error;	offset:28;	size:4;	signed:1;
+ *	field:unsigned short ioprio;	offset:32;	size:2;	signed:0;
+ *	field:char rwbs[8];	offset:34;	size:8;	signed:0;
+ *	field:__data_loc char[] cmd;	offset:44;	size:4;	signed:0;
+ *
+ * print fmt: "%d,%d %s (%s) %llu + %u %s,%u,%u [%d]", ((unsigned int) ((REC->dev) >> 20)), ((unsigned int) ((REC->dev) & ((1U << 20) - 1))), REC->rwbs, __get_str(cmd), (unsigned long long)REC->sector, REC->nr_sector, __print_symbolic((((REC->ioprio) >> 13) & (8 - 1)), { IOPRIO_CLASS_NONE, "none" }, { IOPRIO_CLASS_RT, "rt" }, { IOPRIO_CLASS_BE, "be" }, { IOPRIO_CLASS_IDLE, "idle" }, { IOPRIO_CLASS_INVALID, "invalid"}), (((REC->ioprio) >> 3) & ((1 << 10) - 1)), ((REC->ioprio) & ((1 << 3) - 1)), REC->error
+ */
+#define MINORBITS	20
+#define MINORMASK	((1U << MINORBITS) - 1)
+
+#define MAJOR(dev)	((unsigned int) ((dev) >> MINORBITS))
+#define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
+#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
 int ras_diskerror_event_handler(struct trace_seq *s,
 				struct tep_record *record,
 				struct tep_event *event, void *context);


### PR DESCRIPTION
There is a dev_t type defined by libc for makedev etc, which is exposed by the kernel headers & also a dev_t type defined in the internal kernel headers.
Both have simliar functionality, but different encoding. Copy the MAJOR & MINOR macros from linux/kdev_t.h for proper decoding of the trace events.
Fixes #71

Signed-off-by: scarlet-storm
<12461256+scarlet-storm@users.noreply.github.com>