### PR TITLE
rasdaemon: align event name in log

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -413,7 +413,7 @@ static void parse_ras_data(struct pthread_data *pdata, struct kbuffer *kbuf,
 	/* TODO - logging */
 	trace_seq_init(&s);
 	tep_print_event(pdata->ras->pevent, &s, &record,
-			"%16s-%-5d [%03d] %s %6.1000d %s %s",
+			"%16s-%-10d [%03d] %s %6.1000d %25s: %s",
 			TEP_PRINT_COMM, TEP_PRINT_PID, TEP_PRINT_CPU,
 			TEP_PRINT_LATENCY, TEP_PRINT_TIME, TEP_PRINT_NAME,
 			TEP_PRINT_INFO);


### PR DESCRIPTION
Now rasdaemon event name is not align in log:

```
  <...>-52503 [070] dNh.     0.007127 arm_event ...
  <...>-52503 [052] ....     0.007127 memory_failure_event ...

```
Align it and result look like:

```
  <...>-113714     [059] dNh.     0.007942                 arm_event: ...
  <...>-113714     [069] ....     0.007942      memory_failure_event: ...
```