### PR TITLE
rasdaemon: add event level for event record

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,7 @@ all-local: $(SYSTEMD_SERVICES)
 
 sbin_PROGRAMS = rasdaemon
 rasdaemon_SOURCES = rasdaemon.c ras-events.c ras-mc-handler.c \
-		    bitfield.c trigger.c
+		    bitfield.c trigger.c types.c
 if WITH_SQLITE3
    rasdaemon_SOURCES += ras-record.c
 endif

--- a/man/rasdaemon.1.in
+++ b/man/rasdaemon.1.in
@@ -71,6 +71,21 @@ environment variables. By default the config file is read from /etc/sysconfig/ra
 
 The general format is environmentname=value.
 
+.SH LOG LEVEL
+
+Each log entry has a level prefix that describes the severity of the log to
+help users determine which logs are more valuable.
+Currently, three levels are used:.TP
+
+.B "ALERT"
+The uncorrected hardware error has been fixed, but cause side effects.
+.TP
+.B "CRIT"
+The uncorrected hardware error has been detected.
+.TP
+.B "ERROR"
+The corrected hardware error has been detected.
+
 .SH SEE ALSO
 \fBras-mc-ctl\fR(8)
 

--- a/ras-aer-handler.c
+++ b/ras-aer-handler.c
@@ -81,6 +81,25 @@ int ras_aer_event_handler(struct trace_seq *s,
 	uint8_t sel_data[5];
 	int seg, bus, dev, fn, rc;
 #endif
+	const char *level;
+
+	if (tep_get_field_val(s, event, "severity", record, &severity_val, 1) < 0)
+		return -1;
+	switch (severity_val) {
+	case HW_EVENT_AER_UNCORRECTED_NON_FATAL:
+		level = loglevel_str[LOGLEVEL_CRIT];
+		break;
+	case HW_EVENT_AER_UNCORRECTED_FATAL:
+		level = loglevel_str[LOGLEVEL_EMERG];
+		break;
+	case HW_EVENT_AER_CORRECTED:
+		level = loglevel_str[LOGLEVEL_ERR];
+		break;
+	default:
+		level = loglevel_str[LOGLEVEL_DEBUG];
+		break;
+	}
+	trace_seq_printf(s, "%s ", level);
 
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
@@ -109,9 +128,6 @@ int ras_aer_event_handler(struct trace_seq *s,
 	trace_seq_printf(s, "%s ", ev.dev_name);
 
 	if (tep_get_field_val(s,  event, "status", record, &status_val, 1) < 0)
-		return -1;
-
-	if (tep_get_field_val(s, event, "severity", record, &severity_val, 1) < 0)
 		return -1;
 
 	/* Fills the error buffer. If it is a correctable error then use the

--- a/ras-arm-handler.c
+++ b/ras-arm-handler.c
@@ -489,6 +489,8 @@ int ras_arm_event_handler(struct trace_seq *s,
 
 	memset(&ev, 0, sizeof(ev));
 
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
+
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
 	 * On previous kernels, the way to properly generate an event would

--- a/ras-cxl-handler.c
+++ b/ras-cxl-handler.c
@@ -133,6 +133,7 @@ int ras_cxl_poison_event_handler(struct trace_seq *s,
 	struct ras_events *ras = context;
 	struct ras_cxl_poison_event ev;
 
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	get_timestamp(s, record, ras, (char *)&ev.timestamp, sizeof(ev.timestamp));
 	if (trace_seq_printf(s, "%s ", ev.timestamp) <= 0)
 		return -1;
@@ -345,6 +346,7 @@ int ras_cxl_aer_ue_event_handler(struct trace_seq *s,
 	struct ras_cxl_aer_ue_event ev;
 
 	memset(&ev, 0, sizeof(ev));
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_CRIT]);
 	get_timestamp(s, record, ras, (char *)&ev.timestamp, sizeof(ev.timestamp));
 	if (trace_seq_printf(s, "%s ", ev.timestamp) <= 0)
 		return -1;
@@ -431,6 +433,7 @@ int ras_cxl_aer_ce_event_handler(struct trace_seq *s,
 	struct ras_events *ras = context;
 	struct ras_cxl_aer_ce_event ev;
 
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	get_timestamp(s, record, ras, (char *)&ev.timestamp, sizeof(ev.timestamp));
 	if (trace_seq_printf(s, "%s ", ev.timestamp) <= 0)
 		return -1;
@@ -516,6 +519,7 @@ int ras_cxl_overflow_event_handler(struct trace_seq *s,
 	struct ras_cxl_overflow_event ev;
 
 	memset(&ev, 0, sizeof(ev));
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	get_timestamp(s, record, ras, (char *)&ev.timestamp, sizeof(ev.timestamp));
 	if (trace_seq_printf(s, "%s ", ev.timestamp) <= 0)
 		return -1;
@@ -733,6 +737,7 @@ int ras_cxl_generic_event_handler(struct trace_seq *s,
 	const uint8_t *buf;
 
 	memset(&ev, 0, sizeof(ev));
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	if (handle_ras_cxl_common_hdr(s, record, event, context, &ev.hdr) < 0)
 		return -1;
 
@@ -848,6 +853,7 @@ int ras_cxl_general_media_event_handler(struct trace_seq *s,
 	struct ras_cxl_general_media_event ev;
 
 	memset(&ev, 0, sizeof(ev));
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	if (handle_ras_cxl_common_hdr(s, record, event, context, &ev.hdr) < 0)
 		return -1;
 
@@ -1038,6 +1044,7 @@ int ras_cxl_dram_event_handler(struct trace_seq *s,
 	struct ras_cxl_dram_event ev;
 
 	memset(&ev, 0, sizeof(ev));
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	if (handle_ras_cxl_common_hdr(s, record, event, context, &ev.hdr) < 0)
 		return -1;
 

--- a/ras-devlink-handler.c
+++ b/ras-devlink-handler.c
@@ -83,6 +83,8 @@ int ras_devlink_event_handler(struct trace_seq *s,
 	if (ras->filters[DEVLINK_EVENT] &&
 	    tep_filter_match(ras->filters[DEVLINK_EVENT], record) == FILTER_MATCH)
 		return 0;
+
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
 	 * On previous kernels, the way to properly generate an event would

--- a/ras-diskerror-handler.c
+++ b/ras-diskerror-handler.c
@@ -57,6 +57,7 @@ int ras_diskerror_event_handler(struct trace_seq *s,
 	struct diskerror_event ev;
 	uint32_t dev;
 
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ERR]);
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
 	 * On previous kernels, the way to properly generate an event would

--- a/ras-extlog-handler.c
+++ b/ras-extlog-handler.c
@@ -208,6 +208,26 @@ static void report_extlog_mem_event(struct ras_events *ras,
 				    struct trace_seq *s,
 				    struct ras_extlog_event *ev)
 {
+	const char *level;
+
+	switch (ev->severity) {
+	case 0:
+		level = loglevel_str[LOGLEVEL_CRIT];
+		break;
+	case 1:
+		level = loglevel_str[LOGLEVEL_EMERG];
+		break;
+	case 2:
+		level = loglevel_str[LOGLEVEL_ERR];
+		break;
+	case 3:
+		level = loglevel_str[LOGLEVEL_INFO];
+		break;
+	default:
+		level = loglevel_str[LOGLEVEL_DEBUG];
+		break;
+	}
+	trace_seq_printf(s, "%s ", level);
 	trace_seq_printf(s, "%d %s error: %s physical addr: 0x%llx mask: 0x%llx%s %s %s",
 			 ev->error_seq, err_severity(ev->severity),
 		err_type(ev->etype), ev->address,

--- a/ras-mce-handler.c
+++ b/ras-mce-handler.c
@@ -274,7 +274,16 @@ static void report_mce_event(struct ras_events *ras,
 	time_t now;
 	struct tm *tm;
 	struct mce_priv *mce = ras->mce_priv;
+	const char *level;
 
+	if (e->status & MCI_STATUS_UC)
+		level = loglevel_str[LOGLEVEL_CRIT];
+	else if (e->status & MCI_STATUS_DEFERRED)
+		level = loglevel_str[LOGLEVEL_CRIT];
+	else
+		level = loglevel_str[LOGLEVEL_ERR];
+
+	trace_seq_printf(s, "%s ", level);
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
 	 * On previous kernels, the way to properly generate an event would

--- a/ras-memory-failure-handler.c
+++ b/ras-memory-failure-handler.c
@@ -171,6 +171,7 @@ int ras_memory_failure_event_handler(struct trace_seq *s,
 	struct tm *tm;
 	struct ras_mf_event ev;
 
+	trace_seq_printf(s, "%s ", loglevel_str[LOGLEVEL_ALERT]);
 	/*
 	 * Newer kernels (3.10-rc1 or upper) provide an uptime clock.
 	 * On previous kernels, the way to properly generate an event would

--- a/ras-page-isolation.c
+++ b/ras-page-isolation.c
@@ -15,6 +15,7 @@
 
 #include "ras-logger.h"
 #include "ras-page-isolation.h"
+#include "types.h"
 
 #define PARSED_ENV_LEN 50
 #define ROW_ID_MAX_LEN 200
@@ -347,8 +348,8 @@ static void page_offline(struct page_record *pr)
 
 	pr->offlined = ret < 0 ? PAGE_OFFLINE_FAILED : PAGE_OFFLINE;
 
-	log(TERM, LOG_INFO, "Result of offlining page at %#llx: %s\n",
-	    addr, page_state[pr->offlined]);
+	log(TERM, LOG_INFO, "%s Result of offlining page at %#llx: %s\n",
+	    loglevel_str[LOGLEVEL_ALERT], addr, page_state[pr->offlined]);
 }
 
 static void page_record(struct page_record *pr, unsigned int count, time_t time)

--- a/types.h
+++ b/types.h
@@ -189,4 +189,15 @@ static inline size_t strscat(char *dst, const char *src, size_t dsize)
 		      "pointer type mismatch in container_of()");	\
 	((type *)(__mptr - offsetof(type, member))); })
 
+#define LOGLEVEL_DEFAULT	-1	/* default (or last) loglevel */
+#define LOGLEVEL_EMERG		0	/* system is unusable */
+#define LOGLEVEL_ALERT		1	/* action must be taken immediately */
+#define LOGLEVEL_CRIT		2	/* critical conditions */
+#define LOGLEVEL_ERR		3	/* error conditions */
+#define LOGLEVEL_WARNING	4	/* warning conditions */
+#define LOGLEVEL_NOTICE		5	/* normal but significant condition */
+#define LOGLEVEL_INFO		6	/* informational */
+#define LOGLEVEL_DEBUG		7	/* debug-level messages */
+
+extern const char *loglevel_str[];
 #endif


### PR DESCRIPTION
To help users distinguish more and more events, this patch introduces event levels to indicate the severity of the current event to the system. Currently, three main levels are used: Alert, Crit, Error. Fatal events will be marked as "emerg" but in reality, the kernel will panic upon receiving a fatal event, so rasdaemon does not receive it.

ALERT:	The uncorrected hardware error has been fixed, but cause side effects.
CRIT:	The uncorrected hardware error has been detected. 
ERROR:	The corrected hardware error has been detected.

The log is like follow
        

>  <...>-1367638 [026] d.H.     0.024825 mc_event [CRIT] 2025-03-28 13:28:48 +0800 1 Uncorrected error: multi-bit ECC on unknown memory (mc: 0 address: 0xe53218400 grain: 0 APEI location: node:0 card:2 module:0 rank:0 bank_group:4 bank_address:0 row:25906 column:64 chip_id:0 status(0x0000000000000400): Storage error in DRAM memory)
>            <...>-1367638 [022] ....     0.024825 memory_failure_event [ALERT] 2025-03-28 13:28:48 +0800 pfn=0xe53218 page_type=already truncated LRU page action_result=Recovered