### PR TITLE
Fix for return error code in add_event_handler() and Revert page_size to 4096 in get_pagesize() 

### DIFF
--- a/ras-events.c
+++ b/ras-events.c
@@ -376,7 +376,7 @@ static int filter_ras_mc_event(struct ras_events *ras, char *group, char *event,
 
 static int get_pagesize(struct ras_events *ras, struct tep_handle *pevent)
 {
-	int fd, len, page_size = 8192;
+	int fd, len, page_size = 4096;
 	char buf[page_size];
 
 	fd = open_trace(ras, "events/header_page", O_RDONLY);

--- a/ras-events.c
+++ b/ras-events.c
@@ -864,7 +864,7 @@ static int add_event_handler(struct ras_events *ras, struct tep_handle *pevent,
 			log(TERM, LOG_ERR, "Can't get arch page size\n");
 			free(page);
 			close(fd);
-			return size;
+			return rc;
 		}
 		size += rc;
 	} while (rc > 0);


### PR DESCRIPTION
1. rasdaemon: Fix for return error code in add_event_handler()
2. rasdaemon: Revert page_size to 4096 in get_pagesize() -  This will work when the event data exceed 4096, only after    
    following fix is merged.
     https://github.com/mchehab/rasdaemon/pull/212