### PR TITLE
CXL events handling updation and fixes

### DIFF
--- a/ras-cxl-handler.c
+++ b/ras-cxl-handler.c
@@ -192,7 +192,13 @@ int ras_cxl_poison_event_handler(struct trace_seq *s,
 	if (tep_get_field_val(s, event, "hpa", record, &val, 1) < 0)
 		return -1;
 	ev.hpa = val;
-	if (trace_seq_printf(s, "poison list: hpa:0x%llx ", (unsigned long long)ev.hpa) <= 0)
+	if (trace_seq_printf(s, "hpa:0x%llx ", (unsigned long long)ev.hpa) <= 0)
+		return -1;
+
+	if (tep_get_field_val(s, event, "hpa_alias0", record, &val, 1) < 0)
+		return -1;
+	ev.hpa_alias0 = val;
+	if (trace_seq_printf(s, "hpa_alias0:0x%llx ", (unsigned long long)ev.hpa_alias0) <= 0)
 		return -1;
 
 	if (tep_get_field_val(s, event, "dpa", record, &val, 1) < 0)
@@ -906,6 +912,12 @@ int ras_cxl_general_media_event_handler(struct trace_seq *s,
 	if (trace_seq_printf(s, "hpa:0x%llx ", (unsigned long long)ev.hpa) <= 0)
 		return -1;
 
+	if (tep_get_field_val(s, event, "hpa_alias0", record, &val, 1) < 0)
+		return -1;
+	ev.hpa_alias0 = val;
+	if (trace_seq_printf(s, "hpa_alias0:0x%llx ", (unsigned long long)ev.hpa_alias0) <= 0)
+		return -1;
+
 	ev.region = tep_get_field_raw(s, event, "region_name", record, &len, 1);
 	if (!ev.region)
 		return -1;
@@ -1047,12 +1059,6 @@ int ras_cxl_dram_event_handler(struct trace_seq *s,
 	if (trace_seq_printf(s, "dpa:0x%llx ", (unsigned long long)ev.dpa) <= 0)
 		return -1;
 
-	if (tep_get_field_val(s, event, "hpa", record, &val, 1) < 0)
-		return -1;
-	ev.hpa = val;
-	if (trace_seq_printf(s, "hpa:0x%llx ", (unsigned long long)ev.hpa) <= 0)
-		return -1;
-
 	if (tep_get_field_val(s,  event, "dpa_flags", record, &val, 1) < 0)
 		return -1;
 	ev.dpa_flags = val;
@@ -1102,6 +1108,12 @@ int ras_cxl_dram_event_handler(struct trace_seq *s,
 		return -1;
 	ev.hpa = val;
 	if (trace_seq_printf(s, "hpa:0x%llx ", (unsigned long long)ev.hpa) <= 0)
+		return -1;
+
+	if (tep_get_field_val(s, event, "hpa_alias0", record, &val, 1) < 0)
+		return -1;
+	ev.hpa_alias0 = val;
+	if (trace_seq_printf(s, "hpa_alias0:0x%llx ", (unsigned long long)ev.hpa_alias0) <= 0)
 		return -1;
 
 	ev.region = tep_get_field_raw(s, event, "region_name", record, &len, 1);

--- a/ras-cxl-handler.c
+++ b/ras-cxl-handler.c
@@ -720,11 +720,13 @@ static int handle_ras_cxl_common_hdr(struct trace_seq *s,
 	if (trace_seq_printf(s, "hdr_maint_op_class:%u ", hdr->hdr_maint_op_class) <= 0)
 		return -1;
 
-	if (tep_get_field_val(s,  event, "hdr_maint_op_sub_class", record, &val, 1) < 0)
-		return -1;
-	hdr->hdr_maint_op_sub_class = val;
-	if (trace_seq_printf(s, "hdr_maint_op_sub_class:%u ", hdr->hdr_maint_op_sub_class) <= 0)
-		return -1;
+	if (hdr->hdr_flags & CXL_EVENT_RECORD_FLAG_MAINT_OP_SUB_CLASS_VALID) {
+		if (tep_get_field_val(s,  event, "hdr_maint_op_sub_class", record, &val, 1) < 0)
+			return -1;
+		hdr->hdr_maint_op_sub_class = val;
+		if (trace_seq_printf(s, "hdr_maint_op_sub_class:%u ", hdr->hdr_maint_op_sub_class) <= 0)
+			return -1;
+	}
 
 	return 0;
 }

--- a/ras-cxl-handler.c
+++ b/ras-cxl-handler.c
@@ -1213,7 +1213,7 @@ int ras_cxl_dram_event_handler(struct trace_seq *s,
 	}
 
 #ifdef HAVE_MEMORY_CE_PFA
-	/* Page offline for CE when threeshold is set */
+	/* Page offline for CE when threshold is set */
 	if (!(ev.descriptor & CXL_GMER_EVT_DESC_UNCORRECTABLE_EVENT) &&
 	    (ev.descriptor & CXL_GMER_EVT_DESC_THRESHOLD_EVENT))
 		ras_hw_threshold_pageoffline(ev.hpa);

--- a/ras-record.c
+++ b/ras-record.c
@@ -582,6 +582,7 @@ static const struct db_fields cxl_poison_event_fields[] = {
 	{ .name = "source",		.type = "TEXT" },
 	{ .name = "flags",		.type = "INTEGER" },
 	{ .name = "overflow_ts",	.type = "TEXT" },
+	{ .name = "hpa_alias0",		.type = "INTEGER" },
 };
 
 static const struct db_table_descriptor cxl_poison_event_tab = {
@@ -612,6 +613,7 @@ int ras_store_cxl_poison_event(struct ras_events *ras, struct ras_cxl_poison_eve
 	sqlite3_bind_text(priv->stmt_cxl_poison_event, 11, ev->source, -1, NULL);
 	sqlite3_bind_int(priv->stmt_cxl_poison_event, 12, ev->flags);
 	sqlite3_bind_text(priv->stmt_cxl_poison_event, 13, ev->overflow_ts, -1, NULL);
+	sqlite3_bind_int64(priv->stmt_cxl_poison_event, 14, ev->hpa_alias0);
 
 	rc = sqlite3_step(priv->stmt_cxl_poison_event);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)
@@ -894,6 +896,7 @@ static const struct db_fields cxl_general_media_event_fields[] = {
 	{ .name = "sub_type",		.type = "INTEGER" },
 	{ .name = "cme_threshold_ev_flags",	.type = "INTEGER" },
 	{ .name = "cme_count",		.type = "INTEGER" },
+	{ .name = "hpa_alias0",		.type = "INTEGER" },
 };
 
 static const struct db_table_descriptor cxl_general_media_event_tab = {
@@ -938,6 +941,7 @@ int ras_store_cxl_general_media_event(struct ras_events *ras,
 	sqlite3_bind_int(priv->stmt_cxl_general_media_event, idx++,
 			 ev->cme_threshold_ev_flags);
 	sqlite3_bind_int(priv->stmt_cxl_general_media_event, idx++, ev->cme_count);
+	sqlite3_bind_int64(priv->stmt_cxl_general_media_event, idx++, ev->hpa_alias0);
 
 	rc = sqlite3_step(priv->stmt_cxl_general_media_event);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)
@@ -993,6 +997,7 @@ static const struct db_fields cxl_dram_event_fields[] = {
 	{ .name = "sub_channel",	.type = "INTEGER" },
 	{ .name = "cme_threshold_ev_flags",	.type = "INTEGER" },
 	{ .name = "cvme_count",		.type = "INTEGER" },
+	{ .name = "hpa_alias0",		.type = "INTEGER" },
 };
 
 static const struct db_table_descriptor cxl_dram_event_tab = {
@@ -1043,6 +1048,7 @@ int ras_store_cxl_dram_event(struct ras_events *ras, struct ras_cxl_dram_event *
 	sqlite3_bind_int(priv->stmt_cxl_dram_event, idx++,
 			 ev->cme_threshold_ev_flags);
 	sqlite3_bind_int(priv->stmt_cxl_dram_event, idx++, ev->cvme_count);
+	sqlite3_bind_int64(priv->stmt_cxl_dram_event, idx++, ev->hpa_alias0);
 
 	rc = sqlite3_step(priv->stmt_cxl_dram_event);
 	if (rc != SQLITE_OK && rc != SQLITE_DONE)

--- a/ras-record.h
+++ b/ras-record.h
@@ -124,6 +124,7 @@ struct ras_cxl_poison_event {
 	const char *region;
 	const char *uuid;
 	uint64_t hpa;
+	uint64_t hpa_alias0;
 	uint64_t dpa;
 	uint32_t dpa_length;
 	const char *source;
@@ -206,6 +207,7 @@ struct ras_cxl_general_media_event {
 	uint8_t res_id[CXL_PLDM_RES_ID_LEN];
 	uint16_t validity_flags;
 	uint64_t hpa;
+	uint64_t hpa_alias0;
 	const char *region;
 	const char *region_uuid;
 	uint8_t cme_threshold_ev_flags;
@@ -231,6 +233,7 @@ struct ras_cxl_dram_event {
 	uint8_t *cor_mask;
 	uint16_t validity_flags;
 	uint64_t hpa;
+	uint64_t hpa_alias0;
 	const char *region;
 	const char *region_uuid;
 	uint8_t *comp_id;

--- a/ras-report.c
+++ b/ras-report.c
@@ -553,6 +553,7 @@ static int set_cxl_general_media_event_backtrace(char *buf, struct ras_cxl_gener
 		"hdr_timestamp=%s\n"
 		"hdr_length=%u\n"
 		"hdr_maint_op_class=%u\n"
+		"hdr_maint_op_sub_class=%u\n"
 		"dpa=0x%lx\n"
 		"dpa_flags=%u\n"
 		"descriptor=%u\n"
@@ -580,6 +581,7 @@ static int set_cxl_general_media_event_backtrace(char *buf, struct ras_cxl_gener
 		ev->hdr.hdr_timestamp,
 		ev->hdr.hdr_length,
 		ev->hdr.hdr_maint_op_class,
+		ev->hdr.hdr_maint_op_sub_class,
 		ev->dpa,
 		ev->dpa_flags,
 		ev->descriptor,
@@ -624,6 +626,7 @@ static int set_cxl_dram_event_backtrace(char *buf, struct ras_cxl_dram_event *ev
 		"hdr_timestamp=%s\n"
 		"hdr_length=%u\n"
 		"hdr_maint_op_class=%u\n"
+		"hdr_maint_op_sub_class=%u\n"
 		"dpa=0x%lx\n"
 		"dpa_flags=%u\n"
 		"descriptor=%u\n"
@@ -656,6 +659,7 @@ static int set_cxl_dram_event_backtrace(char *buf, struct ras_cxl_dram_event *ev
 		ev->hdr.hdr_timestamp,
 		ev->hdr.hdr_length,
 		ev->hdr.hdr_maint_op_class,
+		ev->hdr.hdr_maint_op_sub_class,
 		ev->dpa,
 		ev->dpa_flags,
 		ev->descriptor,
@@ -705,6 +709,7 @@ static int set_cxl_memory_module_event_backtrace(char *buf, struct ras_cxl_memor
 		"hdr_timestamp=%s\n"
 		"hdr_length=%u\n"
 		"hdr_maint_op_class=%u\n"
+		"hdr_maint_op_sub_class=%u\n"
 		"event_type=%u\n"
 		"event_sub_type=0x%x\n"
 		"health_status=%u\n"
@@ -727,6 +732,7 @@ static int set_cxl_memory_module_event_backtrace(char *buf, struct ras_cxl_memor
 		ev->hdr.hdr_timestamp,
 		ev->hdr.hdr_length,
 		ev->hdr.hdr_maint_op_class,
+		ev->hdr.hdr_maint_op_sub_class,
 		ev->event_type,
 		ev->event_sub_type,
 		ev->health_status,

--- a/ras-report.c
+++ b/ras-report.c
@@ -372,6 +372,7 @@ static int set_cxl_poison_event_backtrace(char *buf, struct ras_cxl_poison_event
 		"region=%s\n"
 		"region_uuid=%s\n"
 		"hpa=0x%lx\n"
+		"hpa_alias0=0x%lx\n"
 		"dpa=0x%lx\n"
 		"dpa_length=0x%x\n"
 		"source=%s\n"
@@ -385,6 +386,7 @@ static int set_cxl_poison_event_backtrace(char *buf, struct ras_cxl_poison_event
 		ev->region,
 		ev->uuid,
 		ev->hpa,
+		ev->hpa_alias0,
 		ev->dpa,
 		ev->dpa_length,
 		ev->source,
@@ -558,6 +560,7 @@ static int set_cxl_general_media_event_backtrace(char *buf, struct ras_cxl_gener
 		"sub_type=0x%x\n"
 		"transaction_type=%u\n"
 		"hpa=0x%lx\n"
+		"hpa_alias0=0x%lx\n"
 		"region=%s\n"
 		"region_uuid=%s\n"
 		"channel=%u\n"
@@ -584,6 +587,7 @@ static int set_cxl_general_media_event_backtrace(char *buf, struct ras_cxl_gener
 		ev->sub_type,
 		ev->transaction_type,
 		ev->hpa,
+		ev->hpa_alias0,
 		ev->region,
 		ev->region_uuid,
 		ev->channel,
@@ -627,6 +631,7 @@ static int set_cxl_dram_event_backtrace(char *buf, struct ras_cxl_dram_event *ev
 		"sub_type=0x%x\n"
 		"transaction_type=%u\n"
 		"hpa=0x%lx\n"
+		"hpa_alias0=0x%lx\n"
 		"region=%s\n"
 		"region_uuid=%s\n"
 		"channel=%u\n"
@@ -658,6 +663,7 @@ static int set_cxl_dram_event_backtrace(char *buf, struct ras_cxl_dram_event *ev
 		ev->sub_type,
 		ev->transaction_type,
 		ev->hpa,
+		ev->hpa_alias0,
 		ev->region,
 		ev->region_uuid,
 		ev->channel,

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -1843,7 +1843,7 @@ sub errors
     my ($pfn, $page_type, $action_result);
     my ($memdev, $host, $serial, $error_status, $first_error, $header_log);
     my ($log_type, $first_ts, $last_ts);
-    my ($trace_type, $region, $region_uuid, $hpa, $dpa, $dpa_length, $source, $flags, $overflow_ts);
+    my ($trace_type, $region, $region_uuid, $hpa, $hpa_alias0, $dpa, $dpa_length, $source, $flags, $overflow_ts);
     my ($hdr_uuid, $hdr_flags, $hdr_handle, $hdr_related_handle, $hdr_ts, $hdr_length, $hdr_maint_op_class, $hdr_maint_op_sub_class, $data);
     my ($dpa_flags, $descriptor, $mem_event_type, $mem_event_sub_type, $transaction_type, $channel, $rank, $device, $comp_id, $pldm_entity_id, $pldm_res_id);
     my ($nibble_mask, $bank_group, $row, $column, $cor_mask);
@@ -1996,10 +1996,10 @@ sub errors
 	}
 
 	# CXL poison errors
-	$query = "select id, timestamp, memdev, host, serial, trace_type, region, region_uuid, hpa, dpa, dpa_length, source, flags, overflow_ts from cxl_poison_event$conf{opt}{since} order by id";
+	$query = "select id, timestamp, memdev, host, serial, trace_type, region, region_uuid, hpa, dpa, dpa_length, source, flags, overflow_ts, hpa_alias0 from cxl_poison_event$conf{opt}{since} order by id";
 	$query_handle = $dbh->prepare($query);
 	$query_handle->execute();
-	$query_handle->bind_columns(\($id, $timestamp, $memdev, $host, $serial, $trace_type, $region, $region_uuid, $hpa, $dpa, $dpa_length, $source, $flags, $overflow_ts));
+	$query_handle->bind_columns(\($id, $timestamp, $memdev, $host, $serial, $trace_type, $region, $region_uuid, $hpa, $dpa, $dpa_length, $source, $flags, $overflow_ts, $hpa_alias0));
 	$out = "";
 	while($query_handle->fetch()) {
 	    $out .= "$id $timestamp error: ";
@@ -2014,7 +2014,8 @@ sub errors
 	    $out .= sprintf "dpa_length=0x%x, ", $dpa_length if (defined $dpa_length && length $dpa_length);
 	    $out .= "source=$source, " if (defined $source && length $source);
 	    $out .= sprintf "flags=%d, ", $flags if (defined $flags && length $flags);
-	    $out .= "overflow timestamp=$overflow_ts " if (defined $overflow_ts && length $overflow_ts);
+	    $out .= "overflow timestamp=$overflow_ts, " if (defined $overflow_ts && length $overflow_ts);
+	    $out .= sprintf "hpa_alias0=0x%llx, ", $hpa_alias0 if (defined $hpa_alias0 && length $hpa_alias0);
 	    $out .= "\n";
 	}
 	if ($out ne "") {
@@ -2064,12 +2065,12 @@ sub errors
 
 	# CXL general media errors
 	use constant CXL_EVENT_GEN_MED_COMP_ID_SIZE => 0x10;
-	$query = "select id, timestamp, memdev, host, serial, log_type, hdr_uuid, hdr_flags, hdr_handle, hdr_related_handle, hdr_ts, hdr_length, hdr_maint_op_class, hdr_maint_op_sub_class, dpa, dpa_flags, descriptor, type, transaction_type, channel, rank, device, comp_id, hpa, region, region_uuid, pldm_entity_id, pldm_resource_id, sub_type, cme_threshold_ev_flags, cme_count from cxl_general_media_event$conf{opt}{since} order by id";
+	$query = "select id, timestamp, memdev, host, serial, log_type, hdr_uuid, hdr_flags, hdr_handle, hdr_related_handle, hdr_ts, hdr_length, hdr_maint_op_class, hdr_maint_op_sub_class, dpa, dpa_flags, descriptor, type, transaction_type, channel, rank, device, comp_id, hpa, region, region_uuid, pldm_entity_id, pldm_resource_id, sub_type, cme_threshold_ev_flags, cme_count, hpa_alias0 from cxl_general_media_event$conf{opt}{since} order by id";
 	$query_handle = $dbh->prepare($query);
 	$query_handle->execute();
 	use constant CXL_EVENT_GEN_PLDM_ENTITY_ID_SIZE => 0x6;
 	use constant CXL_EVENT_GEN_PLDM_RES_ID_SIZE => 0x4;
-	$query_handle->bind_columns(\($id, $timestamp, $memdev, $host, $serial, $log_type, $hdr_uuid, $hdr_flags, $hdr_handle, $hdr_related_handle, $hdr_ts, $hdr_length, $hdr_maint_op_class, $hdr_maint_op_sub_class, $dpa, $dpa_flags, $descriptor, $mem_event_type, $transaction_type, $channel, $rank, $device, $comp_id, $hpa, $region, $region_uuid, $pldm_entity_id, $pldm_res_id, $sub_type, $cme_threshold_ev_flags, $cme_count));
+	$query_handle->bind_columns(\($id, $timestamp, $memdev, $host, $serial, $log_type, $hdr_uuid, $hdr_flags, $hdr_handle, $hdr_related_handle, $hdr_ts, $hdr_length, $hdr_maint_op_class, $hdr_maint_op_sub_class, $dpa, $dpa_flags, $descriptor, $mem_event_type, $transaction_type, $channel, $rank, $device, $comp_id, $hpa, $region, $region_uuid, $pldm_entity_id, $pldm_res_id, $sub_type, $cme_threshold_ev_flags, $cme_count, $hpa_alias0));
 	$out = "";
 	while($query_handle->fetch()) {
 	    $out .= "$id $timestamp error: ";
@@ -2108,6 +2109,7 @@ sub errors
             $out .= "region_uuid=$region_uuid, " if (defined $region_uuid && length $region_uuid);
             $out .= sprintf "cme_threshold_ev_flags: %s, ", get_cxl_cme_threshold_ev_flags_text($cme_threshold_ev_flags) if (defined $cme_threshold_ev_flags && length $cme_threshold_ev_flags);
             $out .= sprintf "cme_count=%u, ", $cme_count if (defined $cme_count && length $cme_count);
+            $out .= sprintf "hpa_alias0=0x%llx, ", $hpa_alias0 if (defined $hpa_alias0 && length $hpa_alias0);
 	    $out .= "\n";
 	}
 	if ($out ne "") {
@@ -2118,10 +2120,10 @@ sub errors
 
 	# CXL DRAM errors
 	use constant CXL_EVENT_DER_CORRECTION_MASK_SIZE => 0x20;
-	$query = "select id, timestamp, memdev, host, serial, log_type, hdr_uuid, hdr_flags, hdr_handle, hdr_related_handle, hdr_ts, hdr_length, hdr_maint_op_class, hdr_maint_op_sub_class, dpa, dpa_flags, descriptor, type, transaction_type, channel, rank, nibble_mask, bank_group, bank, row, column, cor_mask, hpa, region, region_uuid, comp_id, pldm_entity_id, pldm_resource_id, sub_type, sub_channel, cme_threshold_ev_flags, cvme_count from cxl_dram_event$conf{opt}{since} order by id";
+	$query = "select id, timestamp, memdev, host, serial, log_type, hdr_uuid, hdr_flags, hdr_handle, hdr_related_handle, hdr_ts, hdr_length, hdr_maint_op_class, hdr_maint_op_sub_class, dpa, dpa_flags, descriptor, type, transaction_type, channel, rank, nibble_mask, bank_group, bank, row, column, cor_mask, hpa, region, region_uuid, comp_id, pldm_entity_id, pldm_resource_id, sub_type, sub_channel, cme_threshold_ev_flags, cvme_count, hpa_alias0 from cxl_dram_event$conf{opt}{since} order by id";
 	$query_handle = $dbh->prepare($query);
 	$query_handle->execute();
-	$query_handle->bind_columns(\($id, $timestamp, $memdev, $host, $serial, $log_type, $hdr_uuid, $hdr_flags, $hdr_handle, $hdr_related_handle, $hdr_ts, $hdr_length, $hdr_maint_op_class, $hdr_maint_op_sub_class, $dpa, $dpa_flags, $descriptor, $type, $transaction_type, $channel, $rank, $nibble_mask, $bank_group, $bank, $row, $column, $cor_mask, $hpa, $region, $region_uuid, $comp_id, $pldm_entity_id, $pldm_res_id, $mem_event_sub_type, $sub_channel, $cme_threshold_ev_flags, $cvme_count));
+	$query_handle->bind_columns(\($id, $timestamp, $memdev, $host, $serial, $log_type, $hdr_uuid, $hdr_flags, $hdr_handle, $hdr_related_handle, $hdr_ts, $hdr_length, $hdr_maint_op_class, $hdr_maint_op_sub_class, $dpa, $dpa_flags, $descriptor, $type, $transaction_type, $channel, $rank, $nibble_mask, $bank_group, $bank, $row, $column, $cor_mask, $hpa, $region, $region_uuid, $comp_id, $pldm_entity_id, $pldm_res_id, $mem_event_sub_type, $sub_channel, $cme_threshold_ev_flags, $cvme_count, $hpa_alias0));
 	$out = "";
 	while($query_handle->fetch()) {
 	    $out .= "$id $timestamp error: ";
@@ -2172,6 +2174,7 @@ sub errors
             }
             $out .= sprintf "cme_threshold_ev_flags: %s, ", get_cxl_cme_threshold_ev_flags_text($cme_threshold_ev_flags) if (defined $cme_threshold_ev_flags && length $cme_threshold_ev_flags);
             $out .= sprintf "cvme_count=%u, ", $cvme_count if (defined $cvme_count && length $cvme_count);
+            $out .= sprintf "hpa_alias0=0x%llx, ", $hpa_alias0 if (defined $hpa_alias0 && length $hpa_alias0);
 	    $out .= "\n";
 	}
 	if ($out ne "") {


### PR DESCRIPTION
1.  rasdaemon: cxl: Add parse and log linear cache address alias emission for cxl events
 2. rasdaemon: cxl: Update ras-report.c with missing maintenance operation subclass information
 3. rasdaemon: cxl: Add validity check for parse and log hdr_maint_op_sub_class field
 4. rasdaemon: cxl: Fix typo in ras_cxl_dram_event_handler()
