### PR TITLE
add completions files for zsh and bash

### DIFF
--- a/completions/ras-mc-ctl.bash
+++ b/completions/ras-mc-ctl.bash
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+_ras_mc_ctl() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    opts="--quiet --mainboard --status --print-labels --guess-labels --register-labels 
+          --delay --labeldb --layout --summary --errors --error-count --since 
+          --vendor-errors-summary --vendor-errors --vendor-platforms --help"
+
+    case "${prev}" in
+        --delay)
+            COMPREPLY=($(compgen -W "1 5 10 30 60" -- ${cur}))
+            return 0
+            ;;
+        --labeldb)
+            COMPREPLY=($(compgen -f -- ${cur}))
+            return 0
+            ;;
+        --since)
+            local today=$(date +%Y-%m-%d)
+            local yesterday=$(date -d "1 day ago" +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d 2>/dev/null || echo "")
+            local week_ago=$(date -d "1 week ago" +%Y-%m-%d 2>/dev/null || date -v-1w +%Y-%m-%d 2>/dev/null || echo "")
+            local month_ago=$(date -d "1 month ago" +%Y-%m-%d 2>/dev/null || date -v-1m +%Y-%m-%d 2>/dev/null || echo "")
+            
+            local dates="$today"
+            [[ -n "$yesterday" ]] && dates="$dates $yesterday"
+            [[ -n "$week_ago" ]] && dates="$dates $week_ago"
+            [[ -n "$month_ago" ]] && dates="$dates $month_ago"
+            
+            COMPREPLY=($(compgen -W "$dates" -- ${cur}))
+            return 0
+            ;;
+        --vendor-errors-summary|--vendor-errors)
+            COMPREPLY=()
+            return 0
+            ;;
+    esac
+
+    if [[ ${cur} == --*=* ]]; then
+        local option=${cur%%=*}
+        local value=${cur#*=}
+        
+        case "${option}" in
+            --delay)
+                local suggestions="1 5 10 30 60"
+                COMPREPLY=($(compgen -W "$suggestions" -P "${option}=" -- ${value}))
+                return 0
+                ;;
+            --labeldb)
+                COMPREPLY=($(compgen -f -P "${option}=" -- ${value}))
+                return 0
+                ;;
+            --since)
+                local today=$(date +%Y-%m-%d)
+                local yesterday=$(date -d "1 day ago" +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d 2>/dev/null || echo "")
+                local week_ago=$(date -d "1 week ago" +%Y-%m-%d 2>/dev/null || date -v-1w +%Y-%m-%d 2>/dev/null || echo "")
+                local month_ago=$(date -d "1 month ago" +%Y-%m-%d 2>/dev/null || date -v-1m +%Y-%m-%d 2>/dev/null || echo "")
+                
+                local dates="$today"
+                [[ -n "$yesterday" ]] && dates="$dates $yesterday"
+                [[ -n "$week_ago" ]] && dates="$dates $week_ago"
+                [[ -n "$month_ago" ]] && dates="$dates $month_ago"
+                
+                COMPREPLY=($(compgen -W "$dates" -P "${option}=" -- ${value}))
+                return 0
+                ;;
+        esac
+    fi
+
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+}
+
+complete -F _ras_mc_ctl ras-mc-ctl

--- a/completions/ras-mc-ctl.zsh
+++ b/completions/ras-mc-ctl.zsh
@@ -1,0 +1,47 @@
+#compdef ras-mc-ctl
+
+_ras-mc-ctl() {
+    local context state line
+    typeset -A opt_args
+
+    _arguments -C \
+        '--quiet[Quiet operation]' \
+        '--mainboard[Print mainboard vendor and model for this hardware]' \
+        '--status[Print status of EDAC drivers]' \
+        '--print-labels[Print Motherboard DIMM labels to stdout]' \
+        '--guess-labels[Print DMI labels, when bank locator is available]' \
+        '--register-labels[Load Motherboard DIMM labels into EDAC driver]' \
+        '--delay=[Delay N seconds before writing DIMM labels]:delay (seconds):' \
+        '--labeldb=[Load label database from file DB]:database file:_files' \
+        '--layout[Display the memory layout]' \
+        '--summary[Presents a summary of the logged errors]' \
+        '--errors[Shows the errors stored at the error database]' \
+        '--error-count[Shows the corrected and uncorrected error counts using sysfs]' \
+        '--since=[Only include events since the date YYYY-MM-DD]:date (YYYY-MM-DD):_dates' \
+        '--vendor-errors-summary[Presents a summary of the vendor-specific logged errors]:platform-id:' \
+        '--vendor-errors[Shows the vendor-specific errors stored in the error database]:platform-id:' \
+        '--vendor-platforms[List the supported platforms with platform-ids for the vendor-specific errors]' \
+        '--help[This help message]' \
+        && return 0
+
+    return 1
+}
+
+_dates() {
+    local -a dates
+    local today=$(date +%Y-%m-%d)
+    local yesterday=$(date -d "1 day ago" +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d 2>/dev/null)
+    local week_ago=$(date -d "1 week ago" +%Y-%m-%d 2>/dev/null || date -v-1w +%Y-%m-%d 2>/dev/null)
+    local month_ago=$(date -d "1 month ago" +%Y-%m-%d 2>/dev/null || date -v-1m +%Y-%m-%d 2>/dev/null)
+    
+    dates=(
+        "$today:today"
+        "$yesterday:yesterday" 
+        "$week_ago:1 week ago"
+        "$month_ago:1 month ago"
+    )
+    
+    _describe 'date' dates
+}
+
+_ras-mc-ctl "$@"


### PR DESCRIPTION
`ras-mc-ctl.zsh` should be installed to `/usr/share/zsh/site-functions/_ras-mc-ctl`
`ras-mc-ctl.bash` should be installed to `/usr/share/bash-completion/completions/ras-mc-ctl`

I am unfamiliar with editing the install files.