### PR TITLE
rasdaemon: fix build error when --enable-sqlite3 is not specified

### DIFF
--- a/ras-record.h
+++ b/ras-record.h
@@ -8,7 +8,10 @@
 #ifndef __RAS_RECORD_H
 #define __RAS_RECORD_H
 
+#ifdef HAVE_SQLITE3
 #include <sqlite3.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Building rasdaemon without --enable-sqlite3 results in a compilation error: ras-record.h:11:10: fatal error: sqlite3.h: No such file or directory
 #include <sqlite3.h>
          ^~~~~~~~~~~

This patch ensures that sqlite3.h is only included when SQLite support is enabled via configure.