### PR TITLE
Added AER Uncorrectable Error reporting to SEL on OpenBMC

### DIFF
--- a/unified-sel.c
+++ b/unified-sel.c
@@ -25,6 +25,26 @@ static const char *cor_error_ids[32] = {
 	[15] = "0x07", /* Header Log Overflow */
 };
 
+static const char *uncor_error_ids[32] = {
+    /* Uncorrectable errors */
+    [4] = "0x20",  /* Data Link Protocol */
+    [5] = "0x21",  /* Surprise Down Error */
+    [12] = "0x22", /* Received Poisoned TLP */
+    [13] = "0x23", /* Flow Control Protocol */
+    [14] = "0x24", /* Completion Timeout */
+    [15] = "0x25", /* Completer Abort */
+    [16] = "0x26", /* Unexpected Completion */
+    [17] = "0x27", /* Receiver Overflow */
+    [18] = "0x28", /* Malformed TLP */
+    [19] = "0x29", /* ECRC */
+    [20] = "0x2A", /* Unsupported Request */
+    [21] = "0x2B", /* ACS Violation */
+    [22] = "0x2C", /* Uncorrected Internal */
+    [23] = "0x2D", /* MC Blocked TLP */
+    [24] = "0x2E", /* AtomicOp Egress Blocked */
+    [25] = "0x2F", /* TLP Prefix Blocked */
+};
+
 static int verify_id_log_sel(uint64_t status,
 			     const char **idarray,
 			     unsigned int bus,
@@ -85,6 +105,9 @@ int openbmc_unified_sel_log(uint64_t severity, const char *dev_name, uint64_t st
 	if (severity == HW_EVENT_AER_CORRECTED) {
 		if (verify_id_log_sel(status, cor_error_ids, bus, dev_fn) < 0)
 			return -1;
-	}
+	} else {
+    if (verify_id_log_sel(status, uncor_error_ids, bus, dev_fn) < 0)
+      return -1;
+  }
 	return 0;
 }

--- a/unified-sel.h
+++ b/unified-sel.h
@@ -6,6 +6,8 @@
 #ifndef _UNIFIED_SEL_H
 #define _UNIFIED_SEL_H
 
+#include <stdint.h>
+
 int openbmc_unified_sel_log(uint64_t severity, const char *dev_name, uint64_t status);
 
 #endif


### PR DESCRIPTION
Log to OpenBMC SEL logs all the AER uncorrectable errors that are handled by the kernel. This is a follow up from PR180

Test Plan: Tested on OpenBMC platforms using EINJ
Sign off: Diego Amaya diegoamayaw@meta.com
