### PR TITLE
rasdaemon: Allow for built-in EDAC modules in status check

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -228,11 +228,16 @@ sub run_cmd
 sub print_status
 {
     my $status = 0;
-    open (MODULES, "/proc/modules")
-	 or die "Unable to open /proc/modules: $!\n";
 
-    while (<MODULES>) {
-       $status = 1 if /_edac/;
+    # Check /sys/module/ which contains BOTH built-in and loadable modules
+    if (opendir(my $dh, "/sys/module")) {
+        while (my $entry = readdir($dh)) {
+            if ($entry =~ /edac/) {
+                $status = 1;
+                last;
+            }
+        }
+        closedir($dh);
     }
 
     print "$prog: drivers ", ($status ? "are" : "not"), " loaded.\n"


### PR DESCRIPTION
The existing check for EDAC support when running 'ras-mc-ctl --status' assumes kernel modules, causing the status to incorrectly report that the drivers are not loaded when EDAC is supported by the kernel. Update the status check to also include built-in module support.