### PR TITLE
rasdaemon: fix build when sqlite isn't enabled

### DIFF
--- a/ras-record.h
+++ b/ras-record.h
@@ -8,7 +8,6 @@
 #ifndef __RAS_RECORD_H
 #define __RAS_RECORD_H
 
-#include <sqlite3.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -319,6 +318,8 @@ struct ras_signal_event;
 struct ras_cxl_memory_sparing_event;
 
 #ifdef HAVE_SQLITE3
+
+#include <sqlite3.h>
 
 struct sqlite3_priv {
 	sqlite3		*db;


### PR DESCRIPTION
Build without SQLite enabled through --enable-sqlite3 still fails if sqlite isn't available:
>   CC       rasdaemon-rasdaemon.o
> In file included from rasdaemon.c:17:
> ras-record.h:11:10: fatal error: sqlite3.h: No such file or directory
>    11 | #include <sqlite3.h>
>       |          ^~~~~~~~~~~
> compilation terminated.

Include the sqlite header only if the SQLite feature is enabled.