### PR TITLE
Add NVIDIA non-standard event decoder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,6 +153,10 @@ if WITH_MEMORY_FAILURE
    rasdaemon_SOURCES += ras-memory-failure-handler.c
 endif
 
+if WITH_NVIDIA_NS_DECODE
+   rasdaemon_SOURCES += non-standard-nvidia.c
+endif
+
 if WITH_NON_STANDARD
    rasdaemon_SOURCES += ras-non-standard-handler.c
 endif
@@ -196,6 +200,7 @@ include_HEADERS += unified-sel.h
 include_HEADERS += non-standard-ampere.h
 include_HEADERS += non-standard-hisilicon.h
 include_HEADERS += non-standard-jaguarmicro.h
+include_HEADERS += non-standard-nvidia.h
 include_HEADERS += non-standard-yitian.h
 
 include_HEADERS += ras-aer-handler.h

--- a/configure.ac
+++ b/configure.ac
@@ -252,6 +252,16 @@ AS_IF([test "x$enable_yitian_ns_decode" = "xyes" || test "x$enable_all" == "xyes
 AM_CONDITIONAL([WITH_YITIAN_NS_DECODE], [test x$enable_yitian_ns_decode = xyes || test x$enable_all == xyes])
 AM_COND_IF([WITH_YITIAN_NS_DECODE], [USE_YITIAN_NS_DECODE="yes"], [USE_YITIAN_NS_DECODE="no"])
 
+AC_ARG_ENABLE([nvidia-ns-decode],
+    AS_HELP_STRING([--enable-nvidia-ns-decode], [enable NVIDIA_NS_DECODE events]))
+
+AS_IF([test "x$enable_nvidia_ns_decode" = "xyes" || test "x$enable_all" = "xyes"], [
+  AC_DEFINE(HAVE_NVIDIA_NS_DECODE,1,"have NVIDIA UNKNOWN_SEC events decode")
+  AC_SUBST([WITH_NVIDIA_NS_DECODE])
+])
+AM_CONDITIONAL([WITH_NVIDIA_NS_DECODE], [test x$enable_nvidia_ns_decode = xyes || test x$enable_all = xyes])
+AM_COND_IF([WITH_NVIDIA_NS_DECODE], [USE_NVIDIA_NS_DECODE="yes"], [USE_NVIDIA_NS_DECODE="no"])
+
 AC_ARG_ENABLE([signal],
     AS_HELP_STRING([--enable-signal], [enable signal event(currently experimental)]))
 
@@ -324,6 +334,7 @@ compile time options summary
     CPU fault isolation : $USE_CPU_FAULT_ISOLATION
     YITIAN RAS errors   : $USE_YITIAN_NS_DECODE
     JAGUAR RAS errors   : $USE_JAGUAR_NS_DECODE
+    NVIDIA RAS errors   : $USE_NVIDIA_NS_DECODE
     Signal              : $USE_SIGNAL
     ERST                : $USE_ERST
 EOF

--- a/non-standard-ampere.c
+++ b/non-standard-ampere.c
@@ -476,12 +476,12 @@ static int store_amp_err_data(struct ras_ns_ev_decoder *ev_decoder,
 	int rc;
 
 	rc = sqlite3_step(ev_decoder->stmt_dec_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do %s step on sqlite: error = %d\n", name, rc);
 
 	rc = sqlite3_reset(ev_decoder->stmt_dec_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed to reset %s on sqlite: error = %d\n", name, rc);
 

--- a/non-standard-hisilicon.c
+++ b/non-standard-hisilicon.c
@@ -112,12 +112,12 @@ int step_vendor_data_tab(struct ras_ns_ev_decoder *ev_decoder, const char *name)
 		return 0;
 
 	rc = sqlite3_step(ev_decoder->stmt_dec_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do %s step on sqlite: error = %d\n", name, rc);
 
 	rc = sqlite3_reset(ev_decoder->stmt_dec_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed to reset %s on sqlite: error = %d\n", name, rc);
 

--- a/non-standard-jaguarmicro.c
+++ b/non-standard-jaguarmicro.c
@@ -622,13 +622,13 @@ static int store_jm_err_data(struct ras_ns_ev_decoder *ev_decoder,
 	int rc;
 
 	rc = sqlite3_step(ev_decoder->stmt_dec_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do step on sqlite. Table = %s error = %d\n",
 			tab_name, rc);
 
 	rc = sqlite3_reset(ev_decoder->stmt_dec_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed to reset on sqlite. Table = %s error = %d\n",
 			tab_name, rc);

--- a/non-standard-nvidia.c
+++ b/non-standard-nvidia.c
@@ -1,0 +1,208 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "non-standard-nvidia.h"
+#include "ras-logger.h"
+#include "ras-non-standard-handler.h"
+
+static const char * const nvidia_reg_names[] = {
+	[NVIDIA_FIELD_SIGNATURE]     = "Signature:",
+	[NVIDIA_FIELD_ERROR_TYPE]    = "Error Type:",
+	[NVIDIA_FIELD_ERROR_INSTANCE]= "Error Instance:",
+	[NVIDIA_FIELD_SEVERITY]      = "Severity:",
+	[NVIDIA_FIELD_SOCKET]        = "Socket:",
+	[NVIDIA_FIELD_NUMBER_REGS]   = "Number of Registers:",
+	[NVIDIA_FIELD_INSTANCE_BASE] = "Instance Base:",
+	[NVIDIA_FIELD_REG_DATA]      = "Register Data:",
+};
+
+void decode_nvidia_cper_sec(struct ras_ns_ev_decoder *ev_decoder,
+			    struct trace_seq *s,
+			    const struct nvidia_cper_sec *err,
+			    uint32_t len)
+{
+	uint32_t i, reg_data_len;
+	const struct nvidia_reg_pair *regs;
+
+	trace_seq_printf(s, "%s %s\n",
+			 nvidia_reg_names[NVIDIA_FIELD_SIGNATURE],
+			 err->signature);
+	trace_seq_printf(s, "%s %u\n",
+			 nvidia_reg_names[NVIDIA_FIELD_ERROR_TYPE],
+			 err->error_type);
+	trace_seq_printf(s, "%s %u\n",
+			 nvidia_reg_names[NVIDIA_FIELD_ERROR_INSTANCE],
+			 err->error_instance);
+	trace_seq_printf(s, "%s %u\n",
+			 nvidia_reg_names[NVIDIA_FIELD_SEVERITY],
+			 err->severity);
+	trace_seq_printf(s, "%s %u\n",
+			 nvidia_reg_names[NVIDIA_FIELD_SOCKET],
+			 err->socket);
+	trace_seq_printf(s, "%s %u\n",
+			 nvidia_reg_names[NVIDIA_FIELD_NUMBER_REGS],
+			 err->number_regs);
+	trace_seq_printf(s, "%s 0x%llx\n",
+			 nvidia_reg_names[NVIDIA_FIELD_INSTANCE_BASE],
+			 (unsigned long long)err->instance_base);
+
+	/* Calculate register data length */
+	reg_data_len = len - sizeof(struct nvidia_cper_sec);
+
+	if (err->number_regs > 0 && reg_data_len > 0) {
+		uint32_t expected_size = err->number_regs * sizeof(struct nvidia_reg_pair);
+
+		trace_seq_printf(s, "%s %u bytes (%u register pairs)\n",
+				 nvidia_reg_names[NVIDIA_FIELD_REG_DATA],
+				 reg_data_len, err->number_regs);
+
+		if (reg_data_len >= expected_size) {
+			regs = (const struct nvidia_reg_pair *)((const char *)err + sizeof(struct nvidia_cper_sec));
+
+			/* Print all register pairs */
+			for (i = 0; i < err->number_regs; i++) {
+				trace_seq_printf(s, "  Reg[%u]: addr=0x%llx val=0x%llx\n",
+						 i,
+						 (unsigned long long)regs[i].address,
+						 (unsigned long long)regs[i].value);
+			}
+		} else {
+			trace_seq_printf(s, "  WARNING: Data truncated (expected %u bytes)\n",
+					 expected_size);
+		}
+	}
+}
+
+#ifdef HAVE_SQLITE3
+
+#include <sqlite3.h>
+
+static const struct db_fields nvidia_ns_fields[] = {
+	{ .name = "id",			.type = "INTEGER PRIMARY KEY" },
+	{ .name = "timestamp",		.type = "TEXT" },
+	{ .name = "signature",		.type = "TEXT" },
+	{ .name = "error_type",		.type = "INTEGER" },
+	{ .name = "error_instance",	.type = "INTEGER" },
+	{ .name = "severity",		.type = "INTEGER" },
+	{ .name = "socket",		.type = "INTEGER" },
+	{ .name = "number_regs",	.type = "INTEGER" },
+	{ .name = "instance_base",	.type = "INTEGER" },
+	{ .name = "reg_data",		.type = "BLOB" },
+	{ .name = "raw_data",		.type = "BLOB" },
+};
+
+static const struct db_table_descriptor nvidia_ns_table = {
+	.name = "nvidia_ns_event",
+	.fields = nvidia_ns_fields,
+	.num_fields = ARRAY_SIZE(nvidia_ns_fields),
+};
+
+static int nvidia_ns_add_table(struct ras_events *ras,
+			       struct ras_ns_ev_decoder *ev_decoder)
+{
+	int rc;
+
+	rc = ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
+				     &nvidia_ns_table);
+	if (rc != SQLITE_OK)
+		log(TERM, LOG_ERR, "Failed to create/prepare NVIDIA table: %d\n", rc);
+
+	return rc;
+}
+
+static int nvidia_ns_decode(struct ras_events *ras,
+			    struct ras_ns_ev_decoder *ev_decoder,
+			    struct trace_seq *s,
+			    struct ras_non_standard_event *event)
+{
+	const struct nvidia_cper_sec *err;
+	char timestamp[64];
+	uint32_t reg_data_len;
+	time_t now;
+	struct tm *tm;
+	int rc;
+
+	if (event->length < sizeof(struct nvidia_cper_sec)) {
+		trace_seq_printf(s, "NVIDIA CPER section too small: %u bytes\n",
+				 event->length);
+		return -1;
+	}
+
+	err = (const struct nvidia_cper_sec *)event->error;
+
+	/* Format timestamp */
+	now = time(NULL);
+	tm = localtime(&now);
+	if (tm)
+		strftime(timestamp, sizeof(timestamp),
+			 "%Y-%m-%d %H:%M:%S %z", tm);
+	else
+		strcpy(timestamp, "unknown");
+
+	/* Decode the CPER section for display */
+	decode_nvidia_cper_sec(ev_decoder, s, err, event->length);
+
+	/* Store in database */
+	if (ev_decoder->stmt_dec_record) {
+		reg_data_len = event->length - sizeof(struct nvidia_cper_sec);
+
+		sqlite3_bind_text(ev_decoder->stmt_dec_record, 1, timestamp, -1, SQLITE_TRANSIENT);
+		sqlite3_bind_text(ev_decoder->stmt_dec_record, 2, err->signature, sizeof(err->signature), SQLITE_TRANSIENT);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 3, err->error_type);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 4, err->error_instance);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 5, err->severity);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 6, err->socket);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 7, err->number_regs);
+		sqlite3_bind_int64(ev_decoder->stmt_dec_record, 8, err->instance_base);
+
+		/* Bind register data (parsed from structure) */
+		if (reg_data_len > 0) {
+			const uint8_t *reg_data = (const uint8_t *)err + sizeof(struct nvidia_cper_sec);
+
+			sqlite3_bind_blob(ev_decoder->stmt_dec_record, 9,
+					  reg_data, reg_data_len, SQLITE_TRANSIENT);
+		} else {
+			sqlite3_bind_null(ev_decoder->stmt_dec_record, 9);
+		}
+
+		/* Bind complete raw binary data from the event */
+		sqlite3_bind_blob(ev_decoder->stmt_dec_record, 10,
+				  event->error, event->length, SQLITE_TRANSIENT);
+
+		rc = sqlite3_step(ev_decoder->stmt_dec_record);
+		if (rc != SQLITE_DONE)
+			log(TERM, LOG_ERR,
+			    "Failed to store NVIDIA event in database: error = %d\n", rc);
+
+		rc = sqlite3_reset(ev_decoder->stmt_dec_record);
+		if (rc != SQLITE_OK)
+			log(TERM, LOG_ERR,
+			    "Failed to reset NVIDIA statement: error = %d\n", rc);
+	}
+
+	return 0;
+}
+
+#endif  /* HAVE_SQLITE3 */
+
+/* NVIDIA CPER decoder registration */
+struct ras_ns_ev_decoder nvidia_ns_ev_decoder = {
+	.sec_type = NVIDIA_SEC_TYPE_UUID,
+#ifdef HAVE_SQLITE3
+	.add_table = nvidia_ns_add_table,
+	.decode = nvidia_ns_decode,
+#endif
+};
+
+static void __attribute__((constructor)) nvidia_init(void)
+{
+	register_ns_ev_decoder(&nvidia_ns_ev_decoder);
+}

--- a/non-standard-nvidia.h
+++ b/non-standard-nvidia.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ */
+
+#ifndef __NON_STANDARD_NVIDIA_H
+#define __NON_STANDARD_NVIDIA_H
+
+#include <traceevent/event-parse.h>
+
+#include "types.h"
+
+struct ras_ns_ev_decoder;
+
+#define NVIDIA_SEC_TYPE_UUID "6d5244f2-2712-11ec-bea7-cb3fdb95c786"
+
+/* NVIDIA CPER Error Section Structure */
+struct nvidia_cper_sec {
+	char     signature[16];
+	uint16_t error_type;
+	uint16_t error_instance;
+	uint8_t  severity;
+	uint8_t  socket;
+	uint8_t  number_regs;
+	uint8_t  reserved;
+	uint64_t instance_base;
+	/* Register pairs (address, value) follow */
+} __attribute__((packed));
+
+/* Register pair structure */
+struct nvidia_reg_pair {
+	uint64_t address;
+	uint64_t value;
+} __attribute__((packed));
+
+enum {
+	NVIDIA_FIELD_SIGNATURE,
+	NVIDIA_FIELD_ERROR_TYPE,
+	NVIDIA_FIELD_ERROR_INSTANCE,
+	NVIDIA_FIELD_SEVERITY,
+	NVIDIA_FIELD_SOCKET,
+	NVIDIA_FIELD_NUMBER_REGS,
+	NVIDIA_FIELD_INSTANCE_BASE,
+	NVIDIA_FIELD_REG_DATA,
+};
+
+void decode_nvidia_cper_sec(struct ras_ns_ev_decoder *ev_decoder,
+			    struct trace_seq *s,
+			    const struct nvidia_cper_sec *err,
+			    uint32_t len);
+
+#endif

--- a/non-standard-yitian.c
+++ b/non-standard-yitian.c
@@ -95,11 +95,11 @@ int record_yitian_ddr_reg_dump_event(struct ras_ns_ev_decoder *ev_decoder,
 	sqlite3_bind_text(stmt,  3, ev->reg_msg, -1, NULL);
 
 	rc = sqlite3_step(stmt);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do yitian_ddr_reg_dump_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(stmt);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset yitian_ddr_reg_dump_event on sqlite: error = %d\n", rc);
 	log(TERM, LOG_INFO, "register inserted at db\n");

--- a/ras-non-standard-handler.c
+++ b/ras-non-standard-handler.c
@@ -33,7 +33,7 @@ static char *uuid_le(const char *uu)
 	static const unsigned char le[16] = {3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15};
 
 	for (i = 0; i < 16; i++) {
-		p += snprintf(p, sizeof(uuid), "%.2x", (unsigned char)uu[le[i]]);
+		p += snprintf(p, sizeof(uuid) - (p - uuid), "%.2x", (unsigned char)uu[le[i]]);
 		switch (i) {
 		case 3:
 		case 5:

--- a/ras-record.c
+++ b/ras-record.c
@@ -77,11 +77,11 @@ int ras_store_mc_event(struct ras_events *ras, struct ras_mc_event *ev)
 	sqlite3_bind_int64(priv->stmt_mc_event, 12, ev->syndrome);
 	sqlite3_bind_text(priv->stmt_mc_event, 13, ev->driver_detail, -1, NULL);
 	rc = sqlite3_step(priv->stmt_mc_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do mc_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_mc_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset mc_event on sqlite: error = %d\n",
 		    rc);
@@ -124,11 +124,11 @@ int ras_store_aer_event(struct ras_events *ras, struct ras_aer_event *ev)
 	sqlite3_bind_text(priv->stmt_aer_event,  4, ev->msg, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_aer_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do aer_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_aer_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset aer_event on sqlite: error = %d\n",
 		    rc);
@@ -176,11 +176,11 @@ int ras_store_non_standard_record(struct ras_events *ras, struct ras_non_standar
 	sqlite3_bind_blob(priv->stmt_non_standard_record,  6, ev->error, ev->length, NULL);
 
 	rc = sqlite3_step(priv->stmt_non_standard_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do non_standard_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_non_standard_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset non_standard_event on sqlite: error = %d\n", rc);
 	log(TERM, LOG_INFO, "register inserted at db\n");
@@ -246,11 +246,11 @@ int ras_store_arm_record(struct ras_events *ras, struct ras_arm_event *ev)
 	sqlite3_bind_int64(priv->stmt_arm_record,  14,  ev->phy_fault_addr);
 
 	rc = sqlite3_step(priv->stmt_arm_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do arm_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_arm_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset arm_event on sqlite: error = %d\n",
 		    rc);
@@ -298,11 +298,11 @@ int ras_store_extlog_mem_record(struct ras_events *ras, struct ras_extlog_event 
 	sqlite3_bind_blob(priv->stmt_extlog_record,  8, ev->cper_data, ev->cper_data_length, NULL);
 
 	rc = sqlite3_step(priv->stmt_extlog_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do extlog_mem_record step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_extlog_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset extlog_mem_record on sqlite: error = %d\n",
 		    rc);
@@ -393,11 +393,11 @@ int ras_store_mce_record(struct ras_events *ras, struct mce_event *ev)
 	sqlite3_bind_text(priv->stmt_mce_record, 25, ev->mc_location, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_mce_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do mce_record step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_mce_record);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset mce_record on sqlite: error = %d\n",
 		    rc);
@@ -445,11 +445,11 @@ int ras_store_devlink_event(struct ras_events *ras, struct devlink_event *ev)
 	sqlite3_bind_text(priv->stmt_devlink_event,  6, ev->msg, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_devlink_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do devlink_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_devlink_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset devlink_event on sqlite: error = %d\n",
 		    rc);
@@ -499,11 +499,11 @@ int ras_store_diskerror_event(struct ras_events *ras, struct diskerror_event *ev
 	sqlite3_bind_text(priv->stmt_diskerror_event,  7, ev->cmd, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_diskerror_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do diskerror_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_diskerror_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset diskerror_event on sqlite: error = %d\n",
 		    rc);
@@ -547,12 +547,12 @@ int ras_store_mf_event(struct ras_events *ras, struct ras_mf_event *ev)
 	sqlite3_bind_text(priv->stmt_mf_event,  4, ev->action_result, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_mf_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do memory_failure_event step on sqlite: error = %d\n", rc);
 
 	rc = sqlite3_reset(priv->stmt_mf_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset memory_failure_event on sqlite: error = %d\n",
 		    rc);
@@ -616,11 +616,11 @@ int ras_store_cxl_poison_event(struct ras_events *ras, struct ras_cxl_poison_eve
 	sqlite3_bind_int64(priv->stmt_cxl_poison_event, 14, ev->hpa_alias0);
 
 	rc = sqlite3_step(priv->stmt_cxl_poison_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do cxl_poison_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_poison_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset cxl_poison_event on sqlite: error = %d\n",
 		    rc);
@@ -667,11 +667,11 @@ int ras_store_cxl_aer_ue_event(struct ras_events *ras, struct ras_cxl_aer_ue_eve
 	sqlite3_bind_blob(priv->stmt_cxl_aer_ue_event, 7, ev->header_log, CXL_HEADERLOG_SIZE, NULL);
 
 	rc = sqlite3_step(priv->stmt_cxl_aer_ue_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do cxl_aer_ue_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_aer_ue_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset cxl_aer_ue_event on sqlite: error = %d\n",
 		    rc);
@@ -714,11 +714,11 @@ int ras_store_cxl_aer_ce_event(struct ras_events *ras, struct ras_cxl_aer_ce_eve
 	sqlite3_bind_int(priv->stmt_cxl_aer_ce_event, 5, ev->error_status);
 
 	rc = sqlite3_step(priv->stmt_cxl_aer_ce_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do cxl_aer_ce_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_aer_ce_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset cxl_aer_ce_event on sqlite: error = %d\n",
 		    rc);
@@ -767,11 +767,11 @@ int ras_store_cxl_overflow_event(struct ras_events *ras, struct ras_cxl_overflow
 	sqlite3_bind_text(priv->stmt_cxl_overflow_event, 8, ev->last_ts, -1, NULL);
 
 	rc = sqlite3_step(priv->stmt_cxl_overflow_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do cxl_overflow_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_overflow_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset cxl_overflow_event on sqlite: error = %d\n",
 		    rc);
@@ -853,11 +853,11 @@ int ras_store_cxl_generic_event(struct ras_events *ras, struct ras_cxl_generic_e
 			  CXL_EVENT_RECORD_DATA_LENGTH, NULL);
 
 	rc = sqlite3_step(priv->stmt_cxl_generic_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do stmt_cxl_generic_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_generic_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset stmt_cxl_generic_event on sqlite: error = %d\n", rc);
 	log(TERM, LOG_INFO, "register inserted at db\n");
@@ -950,11 +950,11 @@ int ras_store_cxl_general_media_event(struct ras_events *ras,
 	sqlite3_bind_int64(priv->stmt_cxl_general_media_event, idx++, ev->hpa_alias0);
 
 	rc = sqlite3_step(priv->stmt_cxl_general_media_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do stmt_cxl_general_media_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_general_media_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset stmt_cxl_general_media_event on sqlite: error = %d\n", rc);
 	log(TERM, LOG_INFO, "register inserted at db\n");
@@ -1059,11 +1059,11 @@ int ras_store_cxl_dram_event(struct ras_events *ras, struct ras_cxl_dram_event *
 	sqlite3_bind_int64(priv->stmt_cxl_dram_event, idx++, ev->hpa_alias0);
 
 	rc = sqlite3_step(priv->stmt_cxl_dram_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do stmt_cxl_dram_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_dram_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset stmt_cxl_dram_event on sqlite: error = %d\n", rc);
 	log(TERM, LOG_INFO, "register inserted at db\n");
@@ -1145,11 +1145,11 @@ int ras_store_cxl_memory_module_event(struct ras_events *ras,
 			  CXL_PLDM_RES_ID_LEN, NULL);
 
 	rc = sqlite3_step(priv->stmt_cxl_memory_module_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_DONE)
 		log(TERM, LOG_ERR,
 		    "Failed to do stmt_cxl_memory_module_event step on sqlite: error = %d\n", rc);
 	rc = sqlite3_reset(priv->stmt_cxl_memory_module_event);
-	if (rc != SQLITE_OK && rc != SQLITE_DONE)
+	if (rc != SQLITE_OK)
 		log(TERM, LOG_ERR,
 		    "Failed reset stmt_cxl_memory_module_event on sqlite: error = %d\n", rc);
 	log(TERM, LOG_INFO, "register inserted at db\n");

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -35,6 +35,7 @@ my $has_disk_errors = 0;
 my $has_extlog = 0;
 my $has_mem_failure = 0;
 my $has_mce = 0;
+my $has_nvidia_ns = 0;
 my $has_signal = 0;
 
 @WITH_AER_TRUE@$has_aer = 1;
@@ -45,6 +46,7 @@ my $has_signal = 0;
 @WITH_EXTLOG_TRUE@$has_extlog = 1;
 @WITH_MEMORY_FAILURE_TRUE@$has_mem_failure = 1;
 @WITH_MCE_TRUE@$has_mce = 1;
+@WITH_NVIDIA_NS_DECODE_TRUE@$has_nvidia_ns = 1;
 @WITH_SIGNAL_TRUE@$has_signal = 1;
 
 my %conf        = ();
@@ -1607,6 +1609,25 @@ sub summary
 	$query_handle->finish;
     }
 
+    # NVIDIA events
+    if ($has_nvidia_ns == 1) {
+	$query = "select signature, socket, count(*) from nvidia_ns_event$conf{opt}{since} group by signature, socket";
+	$query_handle = $dbh->prepare($query);
+	$query_handle->execute();
+	my ($signature, $socket);
+	$query_handle->bind_columns(\($signature, $socket, $count));
+	$out = "";
+	while($query_handle->fetch()) {
+	    $out .= sprintf "\tNVIDIA device (signature=%s, socket=%d) has %d errors\n", $signature, $socket, $count;
+	}
+	if ($out ne "") {
+	    print "NVIDIA events summary:\n$out\n";
+	} else {
+	    print "No NVIDIA errors.\n\n";
+	}
+	$query_handle->finish;
+    }
+
     # CXL errors
     if ($has_cxl == 1) {
 	# CXL AER uncorrectable errors
@@ -1931,6 +1952,40 @@ sub errors
 	    print "ARM processor events:\n$out\n";
 	} else {
 	    print "No ARM processor errors.\n\n";
+	}
+	$query_handle->finish;
+    }
+
+    # NVIDIA events
+    if ($has_nvidia_ns == 1) {
+	$query = "select id, timestamp, signature, error_type, error_instance, severity, socket, number_regs, instance_base, reg_data from nvidia_ns_event$conf{opt}{since} order by id";
+	$query_handle = $dbh->prepare($query);
+	$query_handle->execute();
+	my ($signature, $error_type, $error_instance, $severity, $socket, $number_regs, $instance_base, $reg_data);
+	$query_handle->bind_columns(\($id, $timestamp, $signature, $error_type, $error_instance, $severity, $socket, $number_regs, $instance_base, $reg_data));
+	$out = "";
+	while($query_handle->fetch()) {
+	    $out .= "$id $timestamp error: ";
+	    $out .= "signature=$signature, ";
+	    $out .= "error_type=$error_type, ";
+	    $out .= "error_instance=$error_instance, ";
+	    $out .= "severity=$severity, ";
+	    $out .= "socket=$socket, ";
+	    $out .= "number_regs=$number_regs, ";
+	    $out .= sprintf "instance_base=0x%llx", $instance_base;
+	    if (defined $reg_data && length $reg_data) {
+		my $n = int(length($reg_data) / 16);
+		for (my $i = 0; $i < $n; $i++) {
+		    my ($addr, $val) = unpack("Q<Q<", substr($reg_data, $i * 16, 16));
+		    $out .= sprintf "\n  Reg[%u]: addr=0x%016llx val=0x%016llx", $i, $addr, $val;
+		}
+	    }
+	    $out .= "\n";
+	}
+	if ($out ne "") {
+	    print "NVIDIA events:\n$out\n";
+	} else {
+	    print "No NVIDIA errors.\n\n";
 	}
 	$query_handle->finish;
     }


### PR DESCRIPTION
    Add support for decoding NVIDIA CPER errors using the non-standard
    event framework.
    
    The decoder handles NVIDIA-specific error sections with signature,
    error type, severity, socket information, and register pairs data.
    Both parsed register data (reg_data) and complete raw binary data
    (raw_data) are stored as BLOBs for diagnostic use. Reading the raw
    binary requires direct SQL query.
    
    The ras-mc-ctl --errors output includes decoded register address-value
    pairs from the database.
