### PR TITLE
ras-mc-ctl: Fix invalid column in signal events query

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -2497,7 +2497,7 @@ sub errors
 
     # SIGNAL event
     if ($has_signal == 1) {
-	$query = "select id, timestamp, signal, errorno, code, comm, pid, grp, res from signal_event$conf{opt}{since} order by id";
+	$query = "select id, timestamp, sig, errorno, code, comm, pid, grp, res from signal_event$conf{opt}{since} order by id";
 	$query_handle = $dbh->prepare($query);
 	$query_handle->execute();
 	$query_handle->bind_columns(\($id, $timestamp, $signal, $errorno, $code, $comm, $pid, $grp, $res));


### PR DESCRIPTION
ras-mc-ctl use a 'signal' column name but signal_event table contains a 'sig' column. Rename it in the query.

Closes: #237