### PR TITLE
rasdaemon: add NVIDIA Vera non-standard CPER decoder

### DIFF
--- a/non-standard-nvidia.c
+++ b/non-standard-nvidia.c
@@ -4,14 +4,71 @@
  * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
  */
 
-#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #include <time.h>
 
 #include "non-standard-nvidia.h"
 #include "ras-logger.h"
 #include "ras-non-standard-handler.h"
+
+static void nvidia_format_timestamp(char *timestamp, size_t len)
+{
+	time_t now;
+	struct tm *tm;
+
+	if (!timestamp || !len)
+		return;
+
+	now = time(NULL);
+	tm = localtime(&now);
+	if (tm)
+		strftime(timestamp, len, "%Y-%m-%d %H:%M:%S %z", tm);
+	else
+		snprintf(timestamp, len, "unknown");
+}
+
+#ifdef HAVE_SQLITE3
+
+#include <sqlite3.h>
+
+static int nvidia_add_vendor_table(struct ras_events *ras,
+				   struct ras_ns_ev_decoder *ev_decoder,
+				   const struct db_table_descriptor *table,
+				   const char *label)
+{
+	int rc;
+
+	rc = ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record, table);
+	if (rc != SQLITE_OK)
+		log(TERM, LOG_ERR, "Failed to create/prepare %s table: %d\n",
+		    label, rc);
+
+	return rc;
+}
+
+static void nvidia_store_vendor_record(struct ras_ns_ev_decoder *ev_decoder,
+				       const char *label)
+{
+	int rc;
+
+	rc = sqlite3_step(ev_decoder->stmt_dec_record);
+	if (rc != SQLITE_DONE)
+		log(TERM, LOG_ERR,
+		    "Failed to store %s event in database: error = %d\n",
+		    label, rc);
+
+	rc = sqlite3_reset(ev_decoder->stmt_dec_record);
+	if (rc != SQLITE_OK)
+		log(TERM, LOG_ERR,
+		    "Failed to reset %s statement: error = %d\n",
+		    label, rc);
+}
+
+#endif  /* HAVE_SQLITE3 */
 
 static const char * const nvidia_reg_names[] = {
 	[NVIDIA_FIELD_SIGNATURE]     = "Signature:",
@@ -81,9 +138,394 @@ void decode_nvidia_cper_sec(struct ras_ns_ev_decoder *ev_decoder,
 	}
 }
 
-#ifdef HAVE_SQLITE3
+#define NVIDIA_VERA_MAX_CONTEXTS 16
+#define NVIDIA_VERA_VERSION 1
 
-#include <sqlite3.h>
+static uint16_t nvidia_vera_le16(const void *p)
+{
+	uint16_t v;
+
+	memcpy(&v, p, sizeof(v));
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	v = __builtin_bswap16(v);
+#endif
+	return v;
+}
+
+static uint32_t nvidia_vera_le32(const void *p)
+{
+	uint32_t v;
+
+	memcpy(&v, p, sizeof(v));
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	v = __builtin_bswap32(v);
+#endif
+	return v;
+}
+
+static uint64_t nvidia_vera_le64(const void *p)
+{
+	uint64_t v;
+
+	memcpy(&v, p, sizeof(v));
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	v = __builtin_bswap64(v);
+#endif
+	return v;
+}
+
+struct nvidia_vera_event_sec {
+	uint8_t version;
+	uint8_t event_context_count;
+	uint8_t source_device_type;
+	uint8_t reserved;
+	uint16_t event_type;
+	uint16_t event_sub_type;
+	uint64_t event_link_id;
+	char source_module_signature[16];
+} __attribute__((packed));
+
+struct nvidia_vera_cpu_info {
+	uint16_t info_version;
+	uint8_t info_size;
+	uint8_t socket_number;
+	uint32_t architecture;
+	uint8_t chip_serial_number[16];
+	uint64_t instance_base;
+} __attribute__((packed));
+
+struct nvidia_vera_context_sec {
+	uint32_t context_size;
+	uint16_t context_version;
+	uint16_t reserved;
+	uint16_t data_format_type;
+	uint16_t data_format_version;
+	uint32_t data_size;
+} __attribute__((packed));
+
+struct nvidia_vera_context {
+	uint32_t context_size;
+	uint16_t context_version;
+	uint16_t data_format_type;
+	uint16_t data_format_version;
+	uint32_t data_size;
+	const uint8_t *data;
+};
+
+struct nvidia_vera_decoded {
+	char signature[17];
+	uint8_t version;
+	uint8_t event_context_count;
+	uint8_t source_device_type;
+	uint16_t event_type;
+	uint16_t event_sub_type;
+	uint64_t event_link_id;
+	uint8_t socket;
+	uint32_t architecture;
+	uint8_t chip_serial_number[16];
+	uint64_t instance_base;
+	struct nvidia_vera_context contexts[NVIDIA_VERA_MAX_CONTEXTS];
+};
+
+static void nvidia_trace_hex_bytes(struct trace_seq *s, const uint8_t *buf, size_t len)
+{
+	size_t i;
+
+	for (i = 0; i < len; i++)
+		trace_seq_printf(s, "%02x", buf[i]);
+}
+
+static int nvidia_vera_context_entry_count(const struct nvidia_vera_context *ctx)
+{
+	if (!ctx)
+		return -EINVAL;
+	if (ctx->data_size > INT_MAX)
+		return -EOVERFLOW;
+
+	switch (ctx->data_format_type) {
+	case 0:
+		return 0;
+	case 1:
+		return ctx->data_size / 16;
+	case 2:
+	case 3:
+		return ctx->data_size / 8;
+	case 4:
+		return ctx->data_size / 4;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int nvidia_vera_context_u64_pair(const struct nvidia_vera_context *ctx,
+					unsigned int index, uint64_t *addr, uint64_t *val)
+{
+	int count;
+
+	if (!ctx || !addr || !val || ctx->data_format_type != 1)
+		return -EINVAL;
+
+	count = nvidia_vera_context_entry_count(ctx);
+	if (count < 0)
+		return count;
+	if (index >= (unsigned int)count)
+		return -ERANGE;
+
+	*addr = nvidia_vera_le64(ctx->data + index * 16);
+	*val = nvidia_vera_le64(ctx->data + index * 16 + 8);
+
+	return 0;
+}
+
+static int nvidia_vera_context_u32_pair(const struct nvidia_vera_context *ctx,
+					unsigned int index, uint32_t *addr, uint32_t *val)
+{
+	int count;
+
+	if (!ctx || !addr || !val || ctx->data_format_type != 2)
+		return -EINVAL;
+
+	count = nvidia_vera_context_entry_count(ctx);
+	if (count < 0)
+		return count;
+	if (index >= (unsigned int)count)
+		return -ERANGE;
+
+	*addr = nvidia_vera_le32(ctx->data + index * 8);
+	*val = nvidia_vera_le32(ctx->data + index * 8 + 4);
+
+	return 0;
+}
+
+static int nvidia_vera_context_u64_value(const struct nvidia_vera_context *ctx,
+					 unsigned int index, uint64_t *val)
+{
+	int count;
+
+	if (!ctx || !val || ctx->data_format_type != 3)
+		return -EINVAL;
+
+	count = nvidia_vera_context_entry_count(ctx);
+	if (count < 0)
+		return count;
+	if (index >= (unsigned int)count)
+		return -ERANGE;
+
+	*val = nvidia_vera_le64(ctx->data + index * 8);
+
+	return 0;
+}
+
+static int nvidia_vera_context_u32_value(const struct nvidia_vera_context *ctx,
+					 unsigned int index, uint32_t *val)
+{
+	int count;
+
+	if (!ctx || !val || ctx->data_format_type != 4)
+		return -EINVAL;
+
+	count = nvidia_vera_context_entry_count(ctx);
+	if (count < 0)
+		return count;
+	if (index >= (unsigned int)count)
+		return -ERANGE;
+
+	*val = nvidia_vera_le32(ctx->data + index * 4);
+
+	return 0;
+}
+
+static int nvidia_vera_validate_context_data(uint16_t data_format_type,
+					     uint32_t data_size)
+{
+	switch (data_format_type) {
+	case 0:
+		return 0;
+	case 1:
+		return data_size % 16 ? -EINVAL : 0;
+	case 2:
+	case 3:
+		return data_size % 8 ? -EINVAL : 0;
+	case 4:
+		return data_size % 4 ? -EINVAL : 0;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static void nvidia_vera_print_context(struct trace_seq *s,
+				      const struct nvidia_vera_context *ctx,
+				      unsigned int index)
+{
+	int entries;
+	unsigned int i;
+	uint64_t addr64, val64;
+	uint32_t addr32, val32;
+	int rc;
+
+	trace_seq_printf(s,
+			 "context[%u]: version=%u format=%u format_version=%u context_size=%u data_size=%u\n",
+			 index, ctx->context_version, ctx->data_format_type,
+			 ctx->data_format_version, ctx->context_size,
+			 ctx->data_size);
+
+	if (ctx->data_format_type == 0 && ctx->data_size > 0) {
+		unsigned int prefix_len = ctx->data_size > 16 ? 16 : ctx->data_size;
+
+		trace_seq_printf(s, "context[%u]_opaque_prefix: ", index);
+		nvidia_trace_hex_bytes(s, ctx->data, prefix_len);
+		trace_seq_printf(s, "\n");
+		return;
+	}
+
+	entries = nvidia_vera_context_entry_count(ctx);
+	if (entries < 0) {
+		trace_seq_printf(s, "  WARNING: invalid context data (%d)\n", entries);
+		return;
+	}
+
+	trace_seq_printf(s, "context[%u]_entries: %d\n", index, entries);
+
+	for (i = 0; i < (unsigned int)entries; i++) {
+		switch (ctx->data_format_type) {
+		case 1:
+			rc = nvidia_vera_context_u64_pair(ctx, i, &addr64, &val64);
+			if (!rc)
+				trace_seq_printf(s, "  context[%u].reg[%u]: addr=0x%016llx val=0x%016llx\n",
+						 index, i,
+						 (unsigned long long)addr64,
+						 (unsigned long long)val64);
+			break;
+		case 2:
+			rc = nvidia_vera_context_u32_pair(ctx, i, &addr32, &val32);
+			if (!rc)
+				trace_seq_printf(s, "  context[%u].reg[%u]: addr=0x%08x val=0x%08x\n",
+						 index, i, addr32, val32);
+			break;
+		case 3:
+			rc = nvidia_vera_context_u64_value(ctx, i, &val64);
+			if (!rc)
+				trace_seq_printf(s, "  context[%u].value[%u]: 0x%016llx\n",
+						 index, i, (unsigned long long)val64);
+			break;
+		case 4:
+			rc = nvidia_vera_context_u32_value(ctx, i, &val32);
+			if (!rc)
+				trace_seq_printf(s, "  context[%u].value[%u]: 0x%08x\n",
+						 index, i, val32);
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+static int nvidia_decode_vera_cper_sec(const void *buf, size_t len,
+				       struct nvidia_vera_decoded *decoded)
+{
+	const struct nvidia_vera_event_sec *event = buf;
+	const struct nvidia_vera_cpu_info *cpu_info;
+	const struct nvidia_vera_context_sec *context;
+	const uint8_t *bytes = buf;
+	size_t data_end_advance;
+	size_t advance;
+	size_t offset;
+	int i;
+	int ret;
+
+	if (!buf || !decoded)
+		return -EINVAL;
+	if (len < sizeof(*event))
+		return -ENODATA;
+	if (event->version != NVIDIA_VERA_VERSION)
+		return -EOPNOTSUPP;
+	if (event->source_device_type != 0)
+		return -EOPNOTSUPP;
+
+	offset = sizeof(*event);
+	if (len - offset < sizeof(*cpu_info))
+		return -ENODATA;
+
+	cpu_info = (const void *)(bytes + offset);
+	if (cpu_info->info_size < sizeof(*cpu_info))
+		return -EINVAL;
+	if (len - offset < cpu_info->info_size)
+		return -ENODATA;
+
+	offset += cpu_info->info_size;
+	if (event->event_context_count > NVIDIA_VERA_MAX_CONTEXTS)
+		return -E2BIG;
+
+	memset(decoded, 0, sizeof(*decoded));
+	memcpy(decoded->signature, event->source_module_signature,
+	       sizeof(event->source_module_signature));
+	decoded->signature[sizeof(event->source_module_signature)] = '\0';
+	decoded->version = event->version;
+	decoded->event_context_count = event->event_context_count;
+	decoded->source_device_type = event->source_device_type;
+	decoded->event_type = nvidia_vera_le16(&event->event_type);
+	decoded->event_sub_type = nvidia_vera_le16(&event->event_sub_type);
+	decoded->event_link_id = nvidia_vera_le64(&event->event_link_id);
+	decoded->socket = cpu_info->socket_number;
+	decoded->architecture = nvidia_vera_le32(&cpu_info->architecture);
+	memcpy(decoded->chip_serial_number, cpu_info->chip_serial_number,
+	       sizeof(cpu_info->chip_serial_number));
+	decoded->instance_base = nvidia_vera_le64(&cpu_info->instance_base);
+
+	for (i = 0; i < event->event_context_count; i++) {
+		struct nvidia_vera_context *decoded_context = &decoded->contexts[i];
+		uint32_t context_size;
+		uint32_t data_size;
+		uint16_t data_format_type;
+
+		if (len - offset < sizeof(*context))
+			return -ENODATA;
+
+		context = (const void *)(bytes + offset);
+		context_size = nvidia_vera_le32(&context->context_size);
+		data_format_type = nvidia_vera_le16(&context->data_format_type);
+		data_size = nvidia_vera_le32(&context->data_size);
+
+		if (context_size < sizeof(*context))
+			return -EINVAL;
+		if (data_format_type > 4)
+			return -EOPNOTSUPP;
+		if (data_size > SIZE_MAX - sizeof(*context))
+			return -EOVERFLOW;
+
+		data_end_advance = sizeof(*context) + data_size;
+		if (data_end_advance > len - offset)
+			return -ENODATA;
+
+		if (context_size == sizeof(*context))
+			advance = data_end_advance;
+		else if (data_size <= context_size - sizeof(*context))
+			advance = context_size;
+		else
+			return -EINVAL;
+
+		if (advance > len - offset)
+			return -ENODATA;
+
+		ret = nvidia_vera_validate_context_data(data_format_type, data_size);
+		if (ret)
+			return ret;
+
+		decoded_context->context_size = context_size;
+		decoded_context->context_version =
+			nvidia_vera_le16(&context->context_version);
+		decoded_context->data_format_type = data_format_type;
+		decoded_context->data_format_version =
+			nvidia_vera_le16(&context->data_format_version);
+		decoded_context->data_size = data_size;
+		decoded_context->data = bytes + offset + sizeof(*context);
+		offset += advance;
+	}
+
+	return 0;
+}
+
+#ifdef HAVE_SQLITE3
 
 static const struct db_fields nvidia_ns_fields[] = {
 	{ .name = "id",			.type = "INTEGER PRIMARY KEY" },
@@ -108,14 +550,8 @@ static const struct db_table_descriptor nvidia_ns_table = {
 static int nvidia_ns_add_table(struct ras_events *ras,
 			       struct ras_ns_ev_decoder *ev_decoder)
 {
-	int rc;
-
-	rc = ras_mc_add_vendor_table(ras, &ev_decoder->stmt_dec_record,
-				     &nvidia_ns_table);
-	if (rc != SQLITE_OK)
-		log(TERM, LOG_ERR, "Failed to create/prepare NVIDIA table: %d\n", rc);
-
-	return rc;
+	return nvidia_add_vendor_table(ras, ev_decoder, &nvidia_ns_table,
+				       "NVIDIA");
 }
 
 static int nvidia_ns_decode(struct ras_events *ras,
@@ -126,9 +562,6 @@ static int nvidia_ns_decode(struct ras_events *ras,
 	const struct nvidia_cper_sec *err;
 	char timestamp[64];
 	uint32_t reg_data_len;
-	time_t now;
-	struct tm *tm;
-	int rc;
 
 	if (event->length < sizeof(struct nvidia_cper_sec)) {
 		trace_seq_printf(s, "NVIDIA CPER section too small: %u bytes\n",
@@ -138,19 +571,10 @@ static int nvidia_ns_decode(struct ras_events *ras,
 
 	err = (const struct nvidia_cper_sec *)event->error;
 
-	/* Format timestamp */
-	now = time(NULL);
-	tm = localtime(&now);
-	if (tm)
-		strftime(timestamp, sizeof(timestamp),
-			 "%Y-%m-%d %H:%M:%S %z", tm);
-	else
-		strcpy(timestamp, "unknown");
+	nvidia_format_timestamp(timestamp, sizeof(timestamp));
 
-	/* Decode the CPER section for display */
 	decode_nvidia_cper_sec(ev_decoder, s, err, event->length);
 
-	/* Store in database */
 	if (ev_decoder->stmt_dec_record) {
 		reg_data_len = event->length - sizeof(struct nvidia_cper_sec);
 
@@ -163,7 +587,6 @@ static int nvidia_ns_decode(struct ras_events *ras,
 		sqlite3_bind_int(ev_decoder->stmt_dec_record, 7, err->number_regs);
 		sqlite3_bind_int64(ev_decoder->stmt_dec_record, 8, err->instance_base);
 
-		/* Bind register data (parsed from structure) */
 		if (reg_data_len > 0) {
 			const uint8_t *reg_data = (const uint8_t *)err + sizeof(struct nvidia_cper_sec);
 
@@ -173,19 +596,111 @@ static int nvidia_ns_decode(struct ras_events *ras,
 			sqlite3_bind_null(ev_decoder->stmt_dec_record, 9);
 		}
 
-		/* Bind complete raw binary data from the event */
 		sqlite3_bind_blob(ev_decoder->stmt_dec_record, 10,
 				  event->error, event->length, SQLITE_TRANSIENT);
 
-		rc = sqlite3_step(ev_decoder->stmt_dec_record);
-		if (rc != SQLITE_DONE)
-			log(TERM, LOG_ERR,
-			    "Failed to store NVIDIA event in database: error = %d\n", rc);
+		nvidia_store_vendor_record(ev_decoder, "NVIDIA");
+	}
 
-		rc = sqlite3_reset(ev_decoder->stmt_dec_record);
-		if (rc != SQLITE_OK)
-			log(TERM, LOG_ERR,
-			    "Failed to reset NVIDIA statement: error = %d\n", rc);
+	return 0;
+}
+
+static const struct db_fields nvidia_vera_ns_fields[] = {
+	{ .name = "id",				.type = "INTEGER PRIMARY KEY" },
+	{ .name = "timestamp",			.type = "TEXT" },
+	{ .name = "signature",			.type = "TEXT" },
+	{ .name = "event_type",			.type = "INTEGER" },
+	{ .name = "event_sub_type",		.type = "INTEGER" },
+	{ .name = "event_link_id",		.type = "INTEGER" },
+	{ .name = "source_device_type",		.type = "INTEGER" },
+	{ .name = "event_context_count",	.type = "INTEGER" },
+	{ .name = "socket",			.type = "INTEGER" },
+	{ .name = "architecture",		.type = "INTEGER" },
+	{ .name = "chip_serial_number",		.type = "BLOB" },
+	{ .name = "instance_base",		.type = "INTEGER" },
+	{ .name = "raw_data",			.type = "BLOB" },
+};
+
+static const struct db_table_descriptor nvidia_vera_ns_table = {
+	.name = "nvidia_vera_ns_event",
+	.fields = nvidia_vera_ns_fields,
+	.num_fields = ARRAY_SIZE(nvidia_vera_ns_fields),
+};
+
+static int nvidia_vera_ns_add_table(struct ras_events *ras,
+				    struct ras_ns_ev_decoder *ev_decoder)
+{
+	return nvidia_add_vendor_table(ras, ev_decoder, &nvidia_vera_ns_table,
+				       "NVIDIA Vera");
+}
+
+static int nvidia_vera_ns_decode(struct ras_events *ras,
+				 struct ras_ns_ev_decoder *ev_decoder,
+				 struct trace_seq *s,
+				 struct ras_non_standard_event *event)
+{
+	struct nvidia_vera_decoded decoded;
+	char timestamp[64];
+	int rc;
+	unsigned int i;
+
+	if (event->length < sizeof(struct nvidia_vera_event_sec) +
+			   sizeof(struct nvidia_vera_cpu_info)) {
+		trace_seq_printf(s, "NVIDIA Vera CPER section too small: %u bytes\n",
+				 event->length);
+		return -1;
+	}
+
+	rc = nvidia_decode_vera_cper_sec(event->error, event->length, &decoded);
+	if (rc) {
+		trace_seq_printf(s, "Malformed NVIDIA Vera CPER section, error_data_length: %u, ret: %d\n",
+				 event->length, rc);
+		return -1;
+	}
+
+	nvidia_format_timestamp(timestamp, sizeof(timestamp));
+
+	trace_seq_printf(s, "NVIDIA Vera CPER section, error_data_length: %u\n",
+			 event->length);
+	trace_seq_printf(s, "version: %u\n", decoded.version);
+	trace_seq_printf(s, "signature: %s\n", decoded.signature);
+	trace_seq_printf(s, "event_type: %u\n", decoded.event_type);
+	trace_seq_printf(s, "event_sub_type: %u\n", decoded.event_sub_type);
+	trace_seq_printf(s, "event_link_id: 0x%016llx\n",
+			 (unsigned long long)decoded.event_link_id);
+	trace_seq_printf(s, "source_device_type: %u\n", decoded.source_device_type);
+	trace_seq_printf(s, "socket: %u\n", decoded.socket);
+	trace_seq_printf(s, "architecture: 0x%x\n", decoded.architecture);
+	trace_seq_printf(s, "chip_serial_number: ");
+	nvidia_trace_hex_bytes(s, decoded.chip_serial_number,
+			       sizeof(decoded.chip_serial_number));
+	trace_seq_printf(s, "\n");
+	trace_seq_printf(s, "instance_base: 0x%016llx\n",
+			 (unsigned long long)decoded.instance_base);
+	trace_seq_printf(s, "event_context_count: %u\n", decoded.event_context_count);
+
+	for (i = 0; i < decoded.event_context_count; i++)
+		nvidia_vera_print_context(s, &decoded.contexts[i], i);
+
+	if (ev_decoder->stmt_dec_record) {
+		sqlite3_bind_text(ev_decoder->stmt_dec_record, 1, timestamp, -1, SQLITE_TRANSIENT);
+		sqlite3_bind_text(ev_decoder->stmt_dec_record, 2, decoded.signature,
+				  sizeof(decoded.signature) - 1, SQLITE_TRANSIENT);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 3, decoded.event_type);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 4, decoded.event_sub_type);
+		sqlite3_bind_int64(ev_decoder->stmt_dec_record, 5, decoded.event_link_id);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 6, decoded.source_device_type);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 7, decoded.event_context_count);
+		sqlite3_bind_int(ev_decoder->stmt_dec_record, 8, decoded.socket);
+		sqlite3_bind_int64(ev_decoder->stmt_dec_record, 9, decoded.architecture);
+		sqlite3_bind_blob(ev_decoder->stmt_dec_record, 10,
+				  decoded.chip_serial_number,
+				  sizeof(decoded.chip_serial_number), SQLITE_TRANSIENT);
+		sqlite3_bind_int64(ev_decoder->stmt_dec_record, 11, decoded.instance_base);
+		sqlite3_bind_blob(ev_decoder->stmt_dec_record, 12,
+				  event->error, event->length, SQLITE_TRANSIENT);
+
+		nvidia_store_vendor_record(ev_decoder, "NVIDIA Vera");
 	}
 
 	return 0;
@@ -193,16 +708,24 @@ static int nvidia_ns_decode(struct ras_events *ras,
 
 #endif  /* HAVE_SQLITE3 */
 
-/* NVIDIA CPER decoder registration */
 struct ras_ns_ev_decoder nvidia_ns_ev_decoder = {
-	.sec_type = NVIDIA_SEC_TYPE_UUID,
+	.sec_type = NVIDIA_GRACE_SEC_TYPE_UUID,
 #ifdef HAVE_SQLITE3
 	.add_table = nvidia_ns_add_table,
 	.decode = nvidia_ns_decode,
 #endif
 };
 
+static struct ras_ns_ev_decoder nvidia_vera_ns_ev_decoder = {
+	.sec_type = NVIDIA_VERA_SEC_TYPE_UUID,
+#ifdef HAVE_SQLITE3
+	.add_table = nvidia_vera_ns_add_table,
+	.decode = nvidia_vera_ns_decode,
+#endif
+};
+
 static void __attribute__((constructor)) nvidia_init(void)
 {
 	register_ns_ev_decoder(&nvidia_ns_ev_decoder);
+	register_ns_ev_decoder(&nvidia_vera_ns_ev_decoder);
 }

--- a/non-standard-nvidia.h
+++ b/non-standard-nvidia.h
@@ -13,7 +13,8 @@
 
 struct ras_ns_ev_decoder;
 
-#define NVIDIA_SEC_TYPE_UUID "6d5244f2-2712-11ec-bea7-cb3fdb95c786"
+#define NVIDIA_GRACE_SEC_TYPE_UUID "6d5244f2-2712-11ec-bea7-cb3fdb95c786"
+#define NVIDIA_VERA_SEC_TYPE_UUID "9068e568-6ca0-11f0-aeaf-159343591eac"
 
 /* NVIDIA CPER Error Section Structure */
 struct nvidia_cper_sec {

--- a/ras-non-standard-handler.c
+++ b/ras-non-standard-handler.c
@@ -236,8 +236,12 @@ int ras_non_standard_event_handler(struct trace_seq *s,
 		return -1;
 
 	if (!find_ns_ev_decoder(ev.sec_type, &ns_ev_decoder)) {
-		ns_ev_decoder->decode(ras, ns_ev_decoder, s, &ev);
+		if (ns_ev_decoder->decode)
+			ns_ev_decoder->decode(ras, ns_ev_decoder, s, &ev);
+		else
+			goto dump_hex;
 	} else {
+dump_hex:
 		len = ev.length;
 		i = 0;
 		line_count = 0;

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -234,6 +234,23 @@ sub run_cmd
     return ($?>>8);
 }
 
+sub sqlite_table_exists
+{
+    my ($dbh, $table) = @_;
+    my $query = "select 1 from sqlite_master where type='table' and name=?";
+    my $query_handle = $dbh->prepare($query);
+    my $exists = 0;
+
+    return 0 if (!$query_handle);
+
+    $query_handle->execute($table);
+    $query_handle->bind_columns(\my $one);
+    $exists = 1 if ($query_handle->fetch());
+    $query_handle->finish;
+
+    return $exists;
+}
+
 
 sub print_status
 {
@@ -1596,8 +1613,10 @@ sub summary
     my ($etype, $severity, $etype_string, $severity_string);
     my ($dev_name, $dev);
     my ($mpidr, $memdev);
+    my $has_nvidia_vera_ns = 0;
 
     my $dbh = DBI->connect("dbi:SQLite:dbname=$dbname", "", "", {});
+    $has_nvidia_vera_ns = sqlite_table_exists($dbh, "nvidia_vera_ns_event");
 
     # Memory controller mc_event errors
     $query = "select err_type, label, mc, top_layer,middle_layer,lower_layer, count(*) from mc_event$conf{opt}{since} group by err_type, label, mc, top_layer, middle_layer, lower_layer";
@@ -1666,6 +1685,24 @@ sub summary
 	    print "NVIDIA events summary:\n$out\n";
 	} else {
 	    print "No NVIDIA errors.\n\n";
+	}
+	$query_handle->finish;
+    }
+
+    if ($has_nvidia_vera_ns == 1) {
+	$query = "select signature, socket, count(*) from nvidia_vera_ns_event$conf{opt}{since} group by signature, socket";
+	$query_handle = $dbh->prepare($query);
+	$query_handle->execute();
+	my ($signature, $socket);
+	$query_handle->bind_columns(\($signature, $socket, $count));
+	$out = "";
+	while($query_handle->fetch()) {
+	    $out .= sprintf "\tNVIDIA Vera device (signature=%s, socket=%d) has %d errors\n", $signature, $socket, $count;
+	}
+	if ($out ne "") {
+	    print "NVIDIA Vera events summary:\n$out\n";
+	} else {
+	    print "No NVIDIA Vera errors.\n\n";
 	}
 	$query_handle->finish;
     }
@@ -1933,8 +1970,10 @@ sub errors
     my ($event_type, $event_sub_type, $health_status, $media_status, $life_used, $dirty_shutdown_cnt, $cor_vol_err_cnt, $cor_per_err_cnt, $device_temp, $add_status);
     my ($sub_type, $sub_channel, $cme_threshold_ev_flags, $cme_count, $cvme_count);
     my ($signal, $errorno, $code, $comm, $pid, $grp, $res);
+    my $has_nvidia_vera_ns = 0;
 
     my $dbh = DBI->connect("dbi:SQLite:dbname=$dbname", "", "", {});
+    $has_nvidia_vera_ns = sqlite_table_exists($dbh, "nvidia_vera_ns_event");
 
     # Memory controller mc_event errors
     $query = "select id, timestamp, err_count, err_type, err_msg, label, mc, top_layer,middle_layer,lower_layer, address, grain, syndrome, driver_detail from mc_event$conf{opt}{since} order by id";
@@ -2028,6 +2067,37 @@ sub errors
 	    print "NVIDIA events:\n$out\n";
 	} else {
 	    print "No NVIDIA errors.\n\n";
+	}
+	$query_handle->finish;
+    }
+
+    if ($has_nvidia_vera_ns == 1) {
+	$query = "select id, timestamp, signature, event_type, event_sub_type, event_link_id, source_device_type, event_context_count, socket, architecture, chip_serial_number, instance_base from nvidia_vera_ns_event$conf{opt}{since} order by id";
+	$query_handle = $dbh->prepare($query);
+	$query_handle->execute();
+	my ($signature, $event_type, $event_sub_type, $event_link_id, $source_device_type, $event_context_count, $socket, $architecture, $chip_serial_number, $instance_base);
+	$query_handle->bind_columns(\($id, $timestamp, $signature, $event_type, $event_sub_type, $event_link_id, $source_device_type, $event_context_count, $socket, $architecture, $chip_serial_number, $instance_base));
+	$out = "";
+	while($query_handle->fetch()) {
+	    $out .= "$id $timestamp error: ";
+	    $out .= "signature=$signature, ";
+	    $out .= "event_type=$event_type, ";
+	    $out .= "event_sub_type=$event_sub_type, ";
+	    $out .= sprintf "event_link_id=0x%llx, ", $event_link_id;
+	    $out .= "source_device_type=$source_device_type, ";
+	    $out .= "event_context_count=$event_context_count, ";
+	    $out .= "socket=$socket, ";
+	    $out .= sprintf "architecture=0x%x, ", $architecture;
+	    if (defined $chip_serial_number && length $chip_serial_number) {
+		$out .= sprintf "chip_serial_number=%s, ", unpack("H*", $chip_serial_number);
+	    }
+	    $out .= sprintf "instance_base=0x%llx", $instance_base;
+	    $out .= "\n";
+	}
+	if ($out ne "") {
+	    print "NVIDIA Vera events:\n$out\n";
+	} else {
+	    print "No NVIDIA Vera errors.\n\n";
 	}
 	$query_handle->finish;
     }


### PR DESCRIPTION
## Summary

Add NVIDIA Vera non-standard CPER decoding to rasdaemon, alongside the existing Grace decoder in `non-standard-nvidia.c`.

- Register Vera section UUID `9068e568-6ca0-11f0-aeaf-159343591eac` and parse event header, CPU info, and context sections
- Store decoded Vera events in SQLite (`nvidia_vera_ns_event`) and print them via trace output
- Extend `ras-mc-ctl` to report Vera events when the table is present
- Guard against NULL vendor `.decode` handlers when built without SQLite

## Test plan

- [x] Vera EINJ inject — `nvidia_vera_ns_event` recorded and decoded
- [x] Grace EINJ inject — existing `nvidia_ns_event` path still works
- [x] Build with `--enable-sqlite3 --enable-non-standard --enable-nvidia-ns-decode`