### PR TITLE
rasdaemon requires debugfs - add dependency to rasdaemon.service

### DIFF
--- a/misc/rasdaemon.service.in
+++ b/misc/rasdaemon.service.in
@@ -4,6 +4,7 @@
 Description=RAS daemon to log the RAS events
 # only needed when not running in foreground (--foreground | -f)
 #After=syslog.target
+RequiresMountsFor=/sys/kernel/debug
 
 [Service]
 EnvironmentFile=@SYSCONFDEFDIR@/rasdaemon


### PR DESCRIPTION
On a system without debugfs mounted and you try to start rasdaemon you run into:

systemd[1]: Starting RAS daemon to log the RAS events...
rasdaemon[2409]: rasdaemon: Can't find debugfs
rasdaemon[2408]: rasdaemon: Can't locate a mounted debugfs systemd[1]: Started RAS daemon to log the RAS events. rasdaemon[2410]: Can't find debugfs
rasdaemon[2410]: rasdaemon: Can't find debugfs
rasdaemon[2410]: rasdaemon: Can't locate a mounted debugfs systemd[1]: rasdaemon.service: Deactivated successfully.

This change requires/wants debugfs via systemd service file and makes sure debugfs is started before rasdaemon if avail.