### PR TITLE
Makefile.am: install the DIMM label database

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ EXTRA_DIST += completions/ras-mc-ctl.bash
 EXTRA_DIST += completions/ras-mc-ctl.zsh
 EXTRA_DIST += contrib/mem_fail_trigger
 EXTRA_DIST += contrib/mc_event_trigger
+EXTRA_DIST += labels
 EXTRA_DIST += misc/rasdaemon.env
 
 CLEANFILES = misc/rasdaemon.logrotate
@@ -257,6 +258,10 @@ upload:
 # custom target
 install-data-local:
 	$(install_sh) -d "$(DESTDIR)@sysconfdir@/ras/dimm_labels.d"
+	for f in @abs_srcdir@/labels/*; do \
+		test -f "$$f" || continue; \
+		$(install_sh) -m 0644 "$$f" "$(DESTDIR)@sysconfdir@/ras/dimm_labels.d/"; \
+	done
 	$(install_sh) -d "$(DESTDIR)@sysconfdir@/ras/triggers"
 	install -D -p -m 0655 @abs_srcdir@/misc/rasdaemon.env "$(DESTDIR)@SYSCONFDEFDIR@/rasdaemon"
 	$(install_sh) @abs_srcdir@/contrib/mc_event_trigger "$(DESTDIR)@sysconfdir@/ras/triggers/mc_event_trigger"


### PR DESCRIPTION
The `labels/` directory never leaves this repository. It isn't in `EXTRA_DIST`, so `make dist` drops it and the release tarballs contain no labels at all, and `install-data-local` creates `$(sysconfdir)/ras/dimm_labels.d` only to leave it empty.

That combination means no distribution can ship DIMM labels even if it wants to, because the files simply aren't in the source it builds from. On Debian, `dpkg -L rasdaemon` lists `/etc/ras/dimm_labels.d` and nothing inside it. They aren't under `/usr/share/doc` either, so there's no packaged copy for an admin to find.

The visible result is that `ras-mc-ctl` falls back to anonymous EDAC identifiers instead of the slot names printed on the board. I hit this on an ASRockRack ROMED8-2T, where four dual-rank modules show up as eight entries (`rank0`, `rank8`, and so on) with nothing indicating which pairs are the same physical stick. With the label database in place you get the silkscreen names instead:

```
$ ras-mc-ctl --print-labels
LOCATION                  CONFIGURED LABEL   SYSFS CONTENTS
mc0 csrow 0 channel 0     DDR4_A1            DDR4_A1
mc0 csrow 1 channel 0     DDR4_A1            DDR4_A1
```

That only works because I copied the file out of git by hand. Skip that step and `dimm_label` is just empty. Nothing warns you, and the labels never show up. Which also means every labels patch merged here, including my own ROMED8-2T one, currently reaches zero packaged users.

So: add `labels/` to `EXTRA_DIST` so the tarball carries it, and install the contents so `make install` actually populates the directory. Installing the whole database is safe, since `ras-mc-ctl` already reads every file there and matches each against the DMI vendor and model, so other boards' entries are ignored. It's under 20 KiB across eight files.

`EXTRA_DIST += labels` names the directory rather than each file, so new vendor files get picked up without touching this list. Note there is no trailing slash: `EXTRA_DIST += labels/` nests the directory inside itself and the tarball comes out with the files under `labels/labels/`.

The install loop skips non-files, so an empty `labels/` degrades to a no-op rather than failing on a literal glob.

Testing. I built the release tarball, then configured, built and installed from that tarball, which is the path distributions actually take:

```
$ make dist
$ tar tzf rasdaemon-0.8.5.tar.gz | grep -c 'labels/'
9                       # was 0

$ tar xzf rasdaemon-0.8.5.tar.gz && cd rasdaemon-0.8.5
$ ./configure --sysconfdir=/etc && make && make install DESTDIR=/tmp/root
$ ls /tmp/root/etc/ras/dimm_labels.d/
apple  asrock  asus  dell  gigabyte  intel  lenovo  supermicro
                        # was empty
```

Files install 0644. `scripts/checkpatch.pl --git HEAD` is clean.

---

<sub>Slightly gutted this came out as PR #255 rather than #256, one short of a nice round byte. I'll see myself out.</sub>

