### PR TITLE
ras-mc-ctl: fix --layout alignment and add --human

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -866,7 +866,7 @@ sub dimm_display_layer_rev($@)
 	if (!$size) {
 	    $size = 0;
 	}
-	my $s = sprintf "  %4i MB  |", $size;
+	my $s = sprintf "  %6i MB  |", $size;
 	$item_size = length($s);
 	return $s;
     }

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -84,6 +84,7 @@ Usage: $prog [OPTIONS...]
  --delay=N          Delay N seconds before writing DIMM labels.
  --labeldb=DB       Load label database from file DB.
  --layout           Display the memory layout.
+ --human, -h        With --layout, scale DIMM sizes to the largest exact unit.
  --summary          Presents a summary of the logged errors.
  --errors           Shows the errors stored at the error database.
  --error-count      Shows the corrected and uncorrected error counts using sysfs.
@@ -168,6 +169,7 @@ sub parse_cmdline
     $conf{opt}{errors} = 0;
     $conf{opt}{error_count} = 0;
     $conf{opt}{per_rank} = 0;
+    $conf{opt}{human} = 0;
     $conf{opt}{vendor_errors_summary} = 0;
     $conf{opt}{vendor_errors} = 0;
     $conf{opt}{since} = '';
@@ -191,6 +193,7 @@ sub parse_cmdline
 			 "errors" =>          \$conf{opt}{errors},
 			 "error-count" =>     \$conf{opt}{error_count},
 			 "per-rank" =>        \$conf{opt}{per_rank},
+			 "human|h" =>         \$conf{opt}{human},
 			 "vendor-errors-summary" =>    \$conf{opt}{vendor_errors_summary},
 			 "vendor-errors" =>   \$conf{opt}{vendor_errors},
 			 "since=s" =>         \$conf{opt}{since},
@@ -208,6 +211,11 @@ sub parse_cmdline
 
     if ($conf{opt}{per_rank} && !$conf{opt}{error_count}) {
 	log_error ("Only use --per-rank with --error-count\n");
+	exit (1);
+    }
+
+    if ($conf{opt}{human} && !$conf{opt}{display_memory_layout}) {
+	log_error ("Only use --human with --layout\n");
 	exit (1);
     }
 
@@ -866,7 +874,19 @@ sub dimm_display_layer_rev($@)
 	if (!$size) {
 	    $size = 0;
 	}
-	my $s = sprintf "  %6i MB  |", $size;
+	my $s;
+	if ($conf{opt}{human}) {
+	    my @units = ('MB', 'GB', 'TB', 'PB');
+	    my $i = 0;
+	    my $scaled = $size;
+	    while ($scaled >= 1024 && $i < $#units) {
+		$scaled /= 1024;
+		$i++;
+	    }
+	    $s = sprintf "  %4i %s  |", $scaled, $units[$i];
+	} else {
+	    $s = sprintf "  %6i MB  |", $size;
+	}
 	$item_size = length($s);
 	return $s;
     }


### PR DESCRIPTION
Two patches against `--layout`: a fix for the column alignment, and an opt-in flag to scale the sizes.

## The alignment bug

The size cells are built with `sprintf "  %4i MB  |"`. That is a *minimum* field width, not a fixed one, so a cell grows as soon as a value needs more than four digits. `$item_size` is then set from `length()` of whichever cell happened to render last, and the separator rules are drawn from that one value. Once a machine mixes populated and empty slots, the rules stop matching the rows they separate.

On a box with 32GB modules the empty cells are 12 characters and the populated ones are 13, so the table walks:

```
           +-----------------------------------------------+
           |                      mc0                      |
           |  csrow0   |  csrow1   |  csrow2   |  csrow3   |
 ----------+-----------------------------------------------+
 channel5: |  32768 MB  |  32768 MB  |     0 MB  |     0 MB  |
 channel4: |  32768 MB  |  32768 MB  |     0 MB  |     0 MB  |
 ----------+-------------------------------------------------+
```

Measuring the rendered line lengths on that machine gives 59 and 61 for what should be a single width. With `%6i` every cell is 14 characters for any size up to 999999 MB, and the measured widths collapse to a single value of 67.

## Why not the gigabyte conversion

Debian carries a different fix for the same bug, converting the display to GB in rasdaemon 0.8.4-2:

https://sources.debian.org/src/rasdaemon/0.8.4-2/debian/patches/ras-mc-ctl.in/#L10

```
-	my $s = sprintf "  %4i MB  |", $size;
+	my $s = sprintf "  %6i GB  |", $size / 1024;
```

It does restore the alignment, because the values shrink until they fit the original field again. The problem is that `$size` is in megabytes and the division is integer, so anything below 1GB truncates to zero. A 256MB or 512MB module renders as `0 GB`, which is indistinguishable from an empty slot. rasdaemon still supports hardware old enough for that to matter, and the labels directory in this repo covers machines from that era, so the first patch widens the field instead of changing the unit.

## The flag

Large modules in megabytes are genuinely hard to read, which is the reason Debian went to GB in the first place, so the second patch adds `--human` for it. Sizes of at least 1GB print in gigabytes and anything smaller stays in megabytes, so the scaling never loses information:

```
$ ras-mc-ctl --layout --human
 ----------+-----------------------------------------------+
 channel5: |    32 GB  |    32 GB  |     0 MB  |     0 MB  |
 channel4: |    32 GB  |    32 GB  |     0 MB  |     0 MB  |
```

Default output is unchanged. `--human` follows `--per-rank` in being a modifier for exactly one other option, and it is rejected the same way when used without its parent:

```
$ ras-mc-ctl --human
ras-mc-ctl: Error: Only use --human with --layout
```

Between the two patches, Debian can drop its local patch either way: the first gives correct alignment on its own, and `--human` covers the readability case.

## Testing

Built and run against an ASRockRack ROMED8-2T with four 32GB dual-rank DDR4 modules, `amd64_edac`. Verified both directions by measuring the rendered line widths: unpatched gives two distinct widths (59 and 61), patched gives one (67 default, 59 with `--human`). Checked the formatting across 0, 256MB, 512MB, 1GB, 2GB, 32GB, 128GB and 256GB, confirming uniform cell width in both modes and that sub-1GB sizes still report their real value. `scripts/checkpatch.pl` is clean on both commits.

## Two things worth flagging

Adding an option beginning with `h` makes the abbreviation `--h` ambiguous with `--help`, where it previously resolved to help. Single letter abbreviations are already ambiguous for `--s`, `--e`, `--p`, `--v` and `--l`, so this matches existing behaviour, and `--he` and longer still select help. It is called out in the commit message rather than left to be discovered.

Separately, `Getopt::Long::Configure ("bundling")` is set but no short option has ever been defined, so the entire short namespace is free. I did not claim one, since introducing the first short option to the tool seemed like your call rather than mine. If you want `-h` wired to `--human` in the `ls` and `du` sense, or reserved for `--help`, it is a one line follow up either way.
