### PR TITLE
Dmidecode missing

### DIFF
--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -441,6 +441,8 @@ sub guess_vendor_model_dmidecode {
     my ($system_vendor, $system_model);
     my $line = 0;
 
+    return (undef, undef) if ($dmidecode eq "");
+
     $< == 0 || die "Must be root to run dmidecode\n";
 
     open (DMI, "$dmidecode |") or die "failed to run $dmidecode: $!\n";
@@ -549,6 +551,8 @@ sub guess_vendor_model {
 }
 
 sub guess_dimm_label {
+    die "Can't guess DIMM labels: dmidecode not found in PATH\n" if ($dmidecode eq "");
+
     open (DMI, "$dmidecode |") or die "failed to run $dmidecode: $!\n";
 
   LINE:

--- a/util/ras-mc-ctl.in
+++ b/util/ras-mc-ctl.in
@@ -26,6 +26,7 @@ my $dbname      = "@RASSTATEDIR@/@RAS_DB_FNAME@";
 my $prefix      = "@prefix@";
 my $sysconfdir  = "@sysconfdir@";
 my $dmidecode   = find_prog ("dmidecode");
+my $unknown_hw  = "<undefined>";
 
 my $has_aer = 0;
 my $has_arm = 0;
@@ -423,17 +424,17 @@ sub get_mainboard_info {
 	($vendor, $model) = guess_vendor_model ();
     }
 
-    $conf{mainboard}{vendor} = $vendor;
-    $conf{mainboard}{model}  = $model;
+    $conf{mainboard}{vendor} = $vendor || $unknown_hw;
+    $conf{mainboard}{model}  = $model  || $unknown_hw;
 
     ($pvendor, $pname) = guess_product ();
     # since product vendor is rare, use mainboard's vendor
     if ($pvendor) {
 	$conf{mainboard}{product_vendor} = $pvendor;
     } else {
-	$conf{mainboard}{product_vendor} = $vendor;
+	$conf{mainboard}{product_vendor} = $conf{mainboard}{vendor};
     }
-    $conf{mainboard}{product_name} = $pname if $pname;
+    $conf{mainboard}{product_name} = $pname || $unknown_hw;
 }
 
 sub guess_vendor_model_dmidecode {


### PR DESCRIPTION
Fix some ugly script aborts in ras-mc-ctl in case dmidecode is missing and HW info could not be retrieved like:

> ras-mc-ctl --layout, /sbin/ras-mc-ctl --print-labels, /sbin/ras-mc-ctl --guess-labels, /sbin/ras-mc-ctl --layout, /sbin/ras-mc-ctl --error-count

all ended up like this if you have no dmidecode installed (e.g.  always the case on s390x or ppc64le):
>  Missing command in piped open at /sbin/ras-mc-ctl line 414.
>  failed to run : Broken pipe

they now return the proper error:
> ras-mc-ctl --layout
>  ras-mc-ctl: Error: No memories found at via edac.

/sbin/ras-mc-ctl --error-count
ras-mc-ctl: Error: No DIMMs found in /sys or new sysfs EDAC interface not found.

/sbin/ras-mc-ctl --guess-labels
Can't guess DIMM labels: dmidecode not found in PATH

/sbin/ras-mc-ctl --mainboard
ras-mc-ctl: mainboard: <undefined> model <undefined>

