### PR TITLE
rasdaemon: Add some modules supported by HiSilicon HIP13 common section

### DIFF
--- a/non-standard-hisilicon.c
+++ b/non-standard-hisilicon.c
@@ -228,6 +228,13 @@ static const char * const module_name[] = {
 	"CFGBUS",
 	"MPU",
 	"CRG",
+	"ACG3",
+	"DCIP",
+	"UMAU",
+	"UPA",
+	"AXI_MSTR_OOO",
+	"RBIST",
+	"LC300",
 };
 
 static const char * const get_soc_desc(uint8_t soc_id)


### PR DESCRIPTION
Add following updates to the list of modules supported by HiSilicon HIP13 common error section.

  ACG3
  DCIP
  UMAU
  UPA
  AXI_MSTR_OOO
  RBIST
  LC300