### PR TITLE
non-standard: fix buffer overflow in uuid_le()

### DIFF
--- a/ras-non-standard-handler.c
+++ b/ras-non-standard-handler.c
@@ -33,7 +33,7 @@ static char *uuid_le(const char *uu)
 	static const unsigned char le[16] = {3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15};
 
 	for (i = 0; i < 16; i++) {
-		p += snprintf(p, sizeof(uuid), "%.2x", (unsigned char)uu[le[i]]);
+		p += snprintf(p, sizeof(uuid) - (p - uuid), "%.2x", (unsigned char)uu[le[i]]);
 		switch (i) {
 		case 3:
 		case 5:


### PR DESCRIPTION
Fixes the crash reported in #260. `sizeof(uuid)` (the full buffer) was passed as the remaining-space bound to `snprintf` on every loop iteration instead of the actual remaining space, causing `_FORTIFY_SOURCE` to correctly detect an out-of-bounds write and abort. One-line fix: track `p`'s actual offset into the buffer.

See #260 for the full root-cause writeup, reproduction steps, and verification (952 real events processed with zero crashes after the fix, against a live error stream that reliably crashed the unpatched binary on its first event).