### PR TITLE
meson.build: fix prefixed path handling to match Meson expectations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -581,17 +581,17 @@ ras_mc_ctl = configure_file(
 
 rasdaemon_env = prefix / get_option('sysconfdir') / 'sysconfig' / 'rasdaemon'
 install_data('misc/rasdaemon.env',
-    install_dir: get_option('sysconfdir') + '/sysconfig',
+    install_dir: get_option('sysconfdir') / 'sysconfig',
     rename: 'rasdaemon',
 )
 
 install_data('contrib/mc_event_trigger',
-    install_dir: get_option('sysconfdir') + '/ras/triggers',
+    install_dir: get_option('sysconfdir') / 'ras/triggers',
     install_mode: 'rwxr-xr-x',
 )
 
 install_data('contrib/mem_fail_trigger',
-    install_dir: get_option('sysconfdir') + '/ras/triggers',
+    install_dir: get_option('sysconfdir') / 'ras/triggers',
     install_mode: 'rwxr-xr-x',
 )
 
@@ -608,7 +608,7 @@ conf_data = {
     'sysconfdir' : get_option('sysconfdir'),
     'localstatedir' : get_option('localstatedir'),
     'sbindir' : get_option('sbindir'),
-    'SYSCONFDEFDIR' : get_option('sysconfdir') + '/sysconfig',
+    'SYSCONFDEFDIR' : get_option('sysconfdir') / 'sysconfig',
 
     'META_DATE' : run_command('date', '+%d %B %Y', check: true).stdout().strip(),
     'META_ALIAS' : meson.project_name(),
@@ -638,7 +638,7 @@ install_map = {
     'misc/rasdaemon.spec.in' : '',
 
     # Man pages
-    'man/rasdaemon.8.in' : get_option('mandir') + '/man8',
+    'man/rasdaemon.8.in' : get_option('mandir') / 'man8',
 
     # Systemd service files
     'misc/rasdaemon.service.in' : systemd_unitdir,
@@ -648,9 +648,9 @@ install_map = {
     'util/ras_config.py.in': pydir,
 
     # Other files
-    'misc/rasdaemon.syslog-ng.in' : get_option('sysconfdir') + '/syslog-ng/conf.d',
-    'misc/rasdaemon.rsyslog.in' : get_option('sysconfdir') + '/rsyslog.d',
-    'misc/rasdaemon.logrotate.in' : get_option('sysconfdir') + '/logrotate.d',
+    'misc/rasdaemon.syslog-ng.in' : get_option('sysconfdir') / 'syslog-ng/conf.d',
+    'misc/rasdaemon.rsyslog.in' : get_option('sysconfdir') / 'rsyslog.d',
+    'misc/rasdaemon.logrotate.in' : get_option('sysconfdir') / 'logrotate.d',
 }
 
 # File renaming install rules
@@ -722,7 +722,7 @@ endforeach
 
 if labels_list.length() > 0
     install_data(labels_list,
-        install_dir: get_option('sysconfdir') + '/ras/dimm_labels.d',
+        install_dir: get_option('sysconfdir') / 'ras/dimm_labels.d',
         install_mode: 'rw-r--r--',
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -604,11 +604,11 @@ conf_data = {
     'PACKAGE' : meson.project_name(),
     'PACKAGE_VERSION' : meson.project_version(),
 
-    'prefix' : get_option('prefix'),
-    'sysconfdir' : get_option('sysconfdir'),
-    'localstatedir' : get_option('localstatedir'),
-    'sbindir' : get_option('sbindir'),
-    'SYSCONFDEFDIR' : get_option('sysconfdir') / 'sysconfig',
+    'prefix' : prefix,
+    'sysconfdir' : prefix / get_option('sysconfdir'),
+    'localstatedir' : prefix / get_option('localstatedir'),
+    'sbindir' : prefix / get_option('sbindir'),
+    'SYSCONFDEFDIR' : prefix / get_option('sysconfdir') / 'sysconfig',
 
     'META_DATE' : run_command('date', '+%d %B %Y', check: true).stdout().strip(),
     'META_ALIAS' : meson.project_name(),


### PR DESCRIPTION
Currently, when configuring with `meson setup build --prefix=/usr --sbindir=/usr/bin --buildtype release --wipe`, the processed rasdaemon.service is as follows:

```ini
# SPDX-License-Identifier: GPL-2.0-only

[Unit]
Description=RAS daemon to log the RAS events
# only needed when not running in foreground (--foreground | -f)
#After=syslog.target
RequiresMountsFor=/sys/kernel/debug

[Service]
EnvironmentFile=/etc/sysconfig/rasdaemon
ExecStart=bin/rasdaemon -f -r
ExecStartPost=bin/rasdaemon --enable
ExecStop=bin/rasdaemon --disable
Restart=on-abort

[Install]
WantedBy=multi-user.target
```

Note that all rasdaemon paths are missing the prefix, e.g. `ExecStart=bin/rasdaemon -f -r`.

Per <https://mesonbuild.com/Reference-manual_functions_get_option.html>:

> Note that the value returned for built-in options that end in dir such as bindir and libdir is usually a path relative to (and inside) the prefix [...]. `install_dir` arguments handle that as expected but if you need an absolute path, e.g. to use in a define etc., you should use the path concatenation operator like this: `get_option('prefix') / get_option('localstatedir')`. Never manually join paths as if they were strings.

Thus switching to `/` concatenation across all meson.build, and use explicit `prefix /` in `conf_data` definitions. After these fixes, rasdaemon.service can be correctly generated:

```ini
# SPDX-License-Identifier: GPL-2.0-only

[Unit]
Description=RAS daemon to log the RAS events
# only needed when not running in foreground (--foreground | -f)
#After=syslog.target
RequiresMountsFor=/sys/kernel/debug

[Service]
EnvironmentFile=/etc/sysconfig/rasdaemon
ExecStart=/usr/bin/rasdaemon -f -r
ExecStartPost=/usr/bin/rasdaemon --enable
ExecStop=/usr/bin/rasdaemon --disable
Restart=on-abort

[Install]
WantedBy=multi-user.target
```